### PR TITLE
Support for more alternate forms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install sphinx
+            pip install flake8
             python setup.py develop
 
       - save_cache:
@@ -37,6 +38,7 @@ jobs:
           command: |
             . venv/bin/activate
             python setup.py test
+            flake8 --max-line-length=110 text_to_num
 
       # Build the documentation
       - run:

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Parse and convert
     51578302
 
     >>> text2num('mille mille deux cents')
-    AssertionError: not an integer
+    ValueError: invalid literal for text2num: 'mille mille deux cent'
 
 
 Find and transcribe

--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,16 @@ Parse and convert
 .. code-block:: python
 
     >>> from text_to_num import text2num
+    >>> text2num('quatre-vingt-quinze')
+    95
+
     >>> text2num('nonante-cinq')
     95
 
     >>> text2num('mille neuf cent quatre-vingt dix-neuf')
+    1999
+
+    >>> text2num('dix-neuf cent quatre-vingt dix-neuf')
     1999
 
     >>> text2num("cinquante et un million cinq cent soixante dix-huit mille trois cent deux")

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Parse and convert
     51578302
 
     >>> text2num('mille mille deux cents')
-    AssertionError
+    AssertionError: not an integer
 
 
 Find and transcribe

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ text2num
 
 ``text2num`` is a python package that provides functions and parser classes for:
 
-- parsing numbers expressed as words in french and convert them to integer values;
-- detect ordinal, cardinal and decimal numbers in a stream of french words and get their decimal digit representations.
+- parsing numbers expressed as words in French and convert them to integer values;
+- detect ordinal, cardinal and decimal numbers in a stream of French words and get their decimal digit representations.
 
 Compatibility
 -------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,8 +8,8 @@ Welcome to text2num's documentation!
 
 ``text2num`` is a package that provides functions and parser classes for:
 
-- parsing numbers expressed as words in french and convert them to integer values;
-- detect ordinals, cardinals and decimal numbers in a stream of french words and get their decimal digit representations.
+- parsing numbers expressed as words in French and convert them to integer values;
+- detect ordinals, cardinals and decimal numbers in a stream of French words and get their decimal digit representations.
 
 ``text2num`` is distributed under the MIT license and is known to work on python version 3.6 and above.
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -33,7 +33,7 @@ Integers only.
     51578302
 
     >>> text2num('mille mille deux cents')
-    AssertionError
+    AssertionError: not an integer
 
 
 Find and transcribe

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -23,10 +23,16 @@ Integers only.
 .. code-block:: python
 
     >>> from text_to_num import text2num
+    >>> text2num('quatre-vingt-quinze')
+    95
+
     >>> text2num('nonante-cinq')
     95
 
     >>> text2num('mille neuf cent quatre-vingt dix-neuf')
+    1999
+
+    >>> text2num('dix-neuf cent quatre-vingt dix-neuf')
     1999
 
     >>> text2num("cinquante et un million cinq cent soixante dix-huit mille trois cent deux")

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -39,7 +39,7 @@ Integers only.
     51578302
 
     >>> text2num('mille mille deux cents')
-    AssertionError: not an integer
+    ValueError: invalid literal for text2num: 'mille mille deux cent'
 
 
 Find and transcribe

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 
 setup(name='text2num',
       version=VERSION,
-      description='Parse and convert numbers written in french into their digit representation.',
+      description='Parse and convert numbers written in French into their digit representation.',
       long_description=readme(),
       classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -20,7 +20,7 @@ setup(name='text2num',
         'Topic :: Text Processing :: Filters',
         'Natural Language :: French'
       ],
-      keywords='french NLP words-to-numbers',
+      keywords='French NLP words-to-numbers',
       url='https://github.com/allo-media/text2num',
       author='Allo-Media',
       author_email='contact@allo-media.fr',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = '1.0.0'
+VERSION = '1.0.0.dev1'
 
 
 def readme():

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
-import os
-import sys
-
 from setuptools import setup, find_packages
-from setuptools.command.install import install
 
 VERSION = '1.0.0.dev1'
 

--- a/text_to_num/__init__.py
+++ b/text_to_num/__init__.py
@@ -20,4 +20,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .transforms import text2num, alpha2digit
+from .transforms import text2num, alpha2digit  # noqa: F401

--- a/text_to_num/parsers.py
+++ b/text_to_num/parsers.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 """
-Convert french spelled numbers into numeric values or digit strings.
+Convert French spelled numbers into numeric values or digit strings.
 """
 
 #

--- a/text_to_num/parsers.py
+++ b/text_to_num/parsers.py
@@ -174,7 +174,8 @@ class WordStreamValueParser:
         expected = False
         if self.last_word is None:
             expected = True
-        elif self.last_word in UNITS and self.grp_val < 10:
+        elif (self.last_word in UNITS and self.grp_val < 10 or
+              self.last_word in STENS and self.grp_val < 20):
             expected = word in CENT
         elif self.last_word in MTENS:
             expected = word in UNITS or word in STENS and self.last_word in ("soixante", "quatre-vingt")

--- a/text_to_num/parsers.py
+++ b/text_to_num/parsers.py
@@ -1,3 +1,25 @@
+# MIT License
+
+# Copyright (c) 2018 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """
 Convert french spelled numbers into numeric values or digit strings.
 """
@@ -45,11 +67,12 @@ NUMBERS.update(STENS)
 # Exceptions: "soixante" & "quatre-ving" (see Rules)
 MTENS = {
     word: value * 10
-    for value, word in enumerate("vingt trente quarante cinquante soixante septante octante nonante".split(),
+    for value, word in enumerate("vingt trente quarante cinquante soixante septante huitante nonante".split(),
                                  2)
 }
-# Variant
+# Variants
 MTENS['quatre-vingt'] = 80
+MTENS['octante'] = 80
 
 NUMBERS.update(MTENS)
 
@@ -71,7 +94,7 @@ COMPOSITES.update({
     "-".join((ten_word, et_word)): ten_val + et_val
     for ten_word, ten_val in MTENS.items()
     for et_word, et_val in (('et-un', 1), ('et-une', 1))
-    if 10 < ten_val < 80
+    if 10 < ten_val <= 90
 })
 
 COMPOSITES['quatre-vingt-un'] = 81

--- a/text_to_num/tests/test_text_to_num.py
+++ b/text_to_num/tests/test_text_to_num.py
@@ -42,6 +42,16 @@ class TestTextToNum(TestCase):
         test4 = "quatre-vingt un"
         self.assertEqual(text2num(test4), 81)
 
+    def test_text2num_variants(self):
+        self.assertEqual(text2num('quatre-vingt dix-huit'), 98)
+        self.assertEqual(text2num('nonante-huit'), 98)
+        self.assertEqual(text2num('soixante-dix-huit'), 78)
+        self.assertEqual(text2num('septante-huit'), 78)
+        self.assertEqual(text2num('quatre-vingt-huit'), 88)
+        self.assertEqual(text2num('octante-huit'), 88)
+        self.assertEqual(text2num('huitante-huit'), 88)
+        self.assertEqual(text2num('huitante-et-un'), 81)
+
     def test_text2num_exc(self):
         self.assertRaises(AssertionError, text2num, "mille mille deux cent")
 

--- a/text_to_num/tests/test_text_to_num.py
+++ b/text_to_num/tests/test_text_to_num.py
@@ -42,6 +42,9 @@ class TestTextToNum(TestCase):
         test4 = "quatre-vingt un"
         self.assertEqual(text2num(test4), 81)
 
+        self.assertEqual(text2num('quinze'), 15)
+        self.assertEqual(text2num('soixante quinze mille'), 75000)
+
     def test_text2num_variants(self):
         self.assertEqual(text2num('quatre-vingt dix-huit'), 98)
         self.assertEqual(text2num('nonante-huit'), 98)
@@ -52,8 +55,12 @@ class TestTextToNum(TestCase):
         self.assertEqual(text2num('huitante-huit'), 88)
         self.assertEqual(text2num('huitante-et-un'), 81)
 
+    def test_text2num_centuries(self):
+        self.assertEqual(text2num('dix-neuf cent soixante-treize'), 1973)
+
     def test_text2num_exc(self):
         self.assertRaises(AssertionError, text2num, "mille mille deux cent")
+        self.assertRaises(AssertionError, text2num, "soixante quinze cent")
 
     def test_alpha2digit_integers(self):
         source = "Vingt-cinq vaches, douze poulets et cent vingt-cinq kg de pommes de terre."

--- a/text_to_num/tests/test_text_to_num.py
+++ b/text_to_num/tests/test_text_to_num.py
@@ -59,8 +59,8 @@ class TestTextToNum(TestCase):
         self.assertEqual(text2num('dix-neuf cent soixante-treize'), 1973)
 
     def test_text2num_exc(self):
-        self.assertRaises(AssertionError, text2num, "mille mille deux cent")
-        self.assertRaises(AssertionError, text2num, "soixante quinze cent")
+        self.assertRaises(ValueError, text2num, "mille mille deux cent")
+        self.assertRaises(ValueError, text2num, "soixante quinze cent")
 
     def test_alpha2digit_integers(self):
         source = "Vingt-cinq vaches, douze poulets et cent vingt-cinq kg de pommes de terre."

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -28,7 +28,7 @@ from .parsers import WordStreamValueParser, WordToDigitParser
 def look_ahead(sequence):
     """Look-ahead iterator.
 
-    Iterate over a sequence returning couples (current element, next element).
+    Iterate over a sequence by returning couples (current element, next element).
     The last couple returned before StopIteration is raised, is (last element, None).
 
     Example:

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -26,7 +26,17 @@ from .parsers import WordStreamValueParser, WordToDigitParser
 
 
 def look_ahead(sequence):
-    """Look-ahead iterator"""
+    """Look-ahead iterator.
+
+    Iterate over a sequence returning couples (current element, next element).
+    The last couple returned before StopIteration is raised, is (last element, None).
+
+    Example:
+
+    >>> for elt, nxt_elt in look_ahead(sequence):
+    ... # do something
+
+    """
     maxi = len(sequence) - 1
     for i, val in enumerate(sequence):
         ahead = sequence[i + 1] if i < maxi else None

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -44,7 +44,7 @@ def look_ahead(sequence):
 
 
 def text2num(text, relaxed=False):
-    """Convert the ``text`` string containing an integer number written in french
+    """Convert the ``text`` string containing an integer number written in French
     into an integer value.
 
     Set ``relaxed`` to True if you want to accept "quatre vingt(s)" as "quatre-vingt".
@@ -60,7 +60,7 @@ def text2num(text, relaxed=False):
 
 
 def alpha2digit(text, relaxed=False):
-    """Return the text of ``text`` with all the french spelled numbers converted to digits.
+    """Return the text of ``text`` with all the French spelled numbers converted to digits.
     Takes care of punctuation.
     Set ``relaxed`` to True if you want to accept "quatre vingt(s)" as "quatre-vingt".
     """

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -55,7 +55,7 @@ def text2num(text, relaxed=False):
 
     num_parser = WordStreamValueParser(relaxed=relaxed)
     tokens = text.split()
-    assert all(num_parser.push(word, ahead) for word, ahead in look_ahead(tokens))
+    assert all(num_parser.push(word, ahead) for word, ahead in look_ahead(tokens)), 'not an integer'
     return num_parser.value
 
 

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -55,7 +55,8 @@ def text2num(text, relaxed=False):
 
     num_parser = WordStreamValueParser(relaxed=relaxed)
     tokens = text.split()
-    assert all(num_parser.push(word, ahead) for word, ahead in look_ahead(tokens)), 'not an integer'
+    if not all(num_parser.push(word, ahead) for word, ahead in look_ahead(tokens)):
+        raise ValueError('invalid literal for text2num: {}'.format(repr(text)))
     return num_parser.value
 
 


### PR DESCRIPTION
- Support for swiss form *huitante*;
- support for expressions in the form *dix-sept cent quatre-vingt-neuf* that are often used for dates;
- improved documentation for the ``look_ahead`` helper function;
- more consistent exception when invalid value is passed as parameter to `text2num` (fixes #7).