### PR TITLE
New release: 1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,3 +48,49 @@ jobs:
       - store_artifacts:
           path: doc/_build/html/
           destination: html-doc
+
+  deploy:
+    docker:
+      - image: circleci/python:3.6.1
+
+    working_directory: ~/text2num
+
+    steps:
+      - checkout
+
+      - run:
+          name: verify git tag vs. version
+          command: |
+            python setup.py verify
+
+      - run:
+          name: init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = allomedia" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+
+      - run:
+          name: create packages
+          command: |
+            python setup.py sdist
+
+      - run:
+          name: upload to pypi
+          command: |
+            twine upload dist/*
+
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ jobs:
       - run:
           name: upload to pypi
           command: |
+            pip install twine
             twine upload dist/*
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6.1
+
+    working_directory: ~/text2num
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "setup.py" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          # Don't do `python setup.py install` here!
+          name: install inplace with dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install sphinx
+            python setup.py develop
+
+      - save_cache:
+          paths:
+            - ./venv
+
+          key: v1-dependencies-{{ checksum "setup.py" }}
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python setup.py test
+
+      # Build the documentation
+      - run:
+          name: build doc
+          command: |
+            . venv/bin/activate
+            cd doc && make html
+
+      - store_artifacts:
+          path: doc/_build/html/
+          destination: html-doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,8 @@ jobs:
       - run:
           name: upload to pypi
           command: |
+            python3 -m venv venv
+            . venv/bin/activate
             pip install twine
             twine upload dist/*
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,4 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,11 +59,6 @@ jobs:
       - checkout
 
       - run:
-          name: verify git tag vs. version
-          command: |
-            python setup.py verify
-
-      - run:
           name: init .pypirc
           command: |
             echo -e "[pypi]" >> ~/.pypirc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.md
+include README.rst
 include LICENSE

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,11 @@ Compatibility
 
 Tested on python 3.6, 3.7.
 
+License
+-------
+
+This sofware is distributed under the MIT license of which you should have received a copy (see LICENSE file in this repository).
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 text2num
 ========
 
+|docs|
+
+
 ``text2num`` is a python package that provides functions and parser classes for:
 
 - parsing numbers expressed as words in french and convert them to integer values;
@@ -76,7 +79,14 @@ Any numbers, even ordinals.
     Décimaux: 12,99, 120,05 ; mais 60 02.
 
 
+Read the complete documentation on `ReadTheDocs <http://text2num.readthedocs.io/>`_.
+
 Contribute
 ----------
 
 Join us on https://github.com/allo-media/text2num
+
+
+.. |docs| image:: https://readthedocs.org/projects/text2num/badge/?version=latest
+    :target: https://text2num.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Parse and convert
 Find and transcribe
 ~~~~~~~~~~~~~~~~~~~
 
-Any number, even ordinals.
+Any numbers, even ordinals.
 
 .. code-block:: python
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,10 +6,12 @@
 Welcome to text2num's documentation!
 ====================================
 
-``text2num`` is a python package that provides functions and parser classes for:
+``text2num`` is a package that provides functions and parser classes for:
 
 - parsing numbers expressed as words in french and convert them to integer values;
 - detect ordinals, cardinals and decimal numbers in a stream of french words and get their decimal digit representations.
+
+``text2num`` is distributed under the MIT license and is known to work on python version 3.6 and above.
 
 
 .. toctree::
@@ -19,6 +21,7 @@ Welcome to text2num's documentation!
    quickstart
    contribute
    api
+   license
 
 
 

--- a/doc/license.rst
+++ b/doc/license.rst
@@ -1,0 +1,22 @@
+MIT License
+===========
+
+Copyright (c) 2018 Groupe Allo-Media
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,10 @@
+import os
+import sys
+
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+VERSION = '1.0.0'
 
 
 def readme():
@@ -6,8 +12,22 @@ def readme():
         return f.read()
 
 
+class VerifyVersionCommand(install):
+    """Custom command to verify that the git tag matches our version"""
+    description = 'verify that the git tag matches our version'
+
+    def run(self):
+        tag = os.getenv('CIRCLE_TAG')
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
+
+
 setup(name='text2num',
-      version='1.0',
+      version=VERSION,
       description='Parse and convert numbers written in french into their digit representation.',
       long_description=readme(),
       classifiers=[
@@ -27,6 +47,8 @@ setup(name='text2num',
       # install_requires=[
       #     'markdown',
       # ],
+      python_requires='>=3',
       test_suite='text_to_num.tests',
       include_package_data=True,
-      zip_safe=False)
+      zip_safe=False,
+      cmdclass={'verify': VerifyVersionCommand})

--- a/setup.py
+++ b/setup.py
@@ -12,20 +12,6 @@ def readme():
         return f.read()
 
 
-class VerifyVersionCommand(install):
-    """Custom command to verify that the git tag matches our version"""
-    description = 'verify that the git tag matches our version'
-
-    def run(self):
-        tag = os.getenv('CIRCLE_TAG')
-
-        if tag != VERSION:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, VERSION
-            )
-            sys.exit(info)
-
-
 setup(name='text2num',
       version=VERSION,
       description='Parse and convert numbers written in french into their digit representation.',
@@ -50,5 +36,4 @@ setup(name='text2num',
       python_requires='>=3',
       test_suite='text_to_num.tests',
       include_package_data=True,
-      zip_safe=False,
-      cmdclass={'verify': VerifyVersionCommand})
+      zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.0.0.dev1'
+VERSION = '1.1.0'
 
 
 def readme():

--- a/text_to_num/__init__.py
+++ b/text_to_num/__init__.py
@@ -1,1 +1,23 @@
+# MIT License
+
+# Copyright (c) 2018 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from .transforms import text2num, alpha2digit

--- a/text_to_num/tests/__init__.py
+++ b/text_to_num/tests/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+
+# Copyright (c) 2018 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/text_to_num/tests/test_text_to_num.py
+++ b/text_to_num/tests/test_text_to_num.py
@@ -1,3 +1,26 @@
+# MIT License
+
+# Copyright (c) 2018 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 """
 Test the ``text_to_num`` library.
 """

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -1,3 +1,25 @@
+# MIT License
+
+# Copyright (c) 2018 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import re
 
 from .parsers import WordStreamValueParser, WordToDigitParser


### PR DESCRIPTION
- Support for swiss form *huitante*;
- support for expressions in the form *dix-sept cent quatre-vingt-neuf* that are often used for dates;
- improved documentation for the ``look_ahead`` helper function;
- more consistent exception when invalid value is passed as parameter to `text2num` (fixes #7).