### PR TITLE
One and second as nouns or determiners

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-VERSION = "2.0.1"
+VERSION = "2.1.0"
 
 
 def readme():

--- a/tests/test_text_to_num_en.py
+++ b/tests/test_text_to_num_en.py
@@ -129,9 +129,9 @@ class TestTextToNumEN(TestCase):
 
     def test_alpha2digit_ordinals(self):
         source = (
-            "Fifth third twenty-first hundredth one thousand two hundred thirtieth."
+            "Fifth third second twenty-first hundredth one thousand two hundred thirtieth."
         )
-        expected = "5th 3rd 21st 100th 1230th."
+        expected = "5th third second 21st 100th 1230th."
         self.assertEqual(alpha2digit(source, "en"), expected)
 
     def test_alpha2digit_decimals(self):
@@ -148,3 +148,17 @@ class TestTextToNumEN(TestCase):
         source = "We have plus twenty degrees inside and minus fifteen outside."
         expected = "We have +20 degrees inside and -15 outside."
         self.assertEqual(alpha2digit(source, "en"), expected)
+
+    def test_one_as_noun_or_article(self):
+        source = "This is the one I'm looking for. One moment please! Twenty one."
+        expected = "This is the one I'm looking for. One moment please! 21."
+        self.assertEqual(alpha2digit(source, "en"), expected)
+        source = "No one is innocent. Another one bites the dust."
+        self.assertEqual(alpha2digit(source, "en"), source)
+
+    def test_second_as_time_unit_vs_ordinal(self):
+        source = "One second please! twenty second is parsed as twenty-second and is different from twenty seconds."
+        expected = "One second please! 22nd is parsed as 22nd and is different from 20 seconds."
+        self.assertEqual(alpha2digit(source, "en"), expected)
+
+

--- a/tests/test_text_to_num_fr.py
+++ b/tests/test_text_to_num_fr.py
@@ -145,9 +145,9 @@ class TestTextToNumFR(TestCase):
 
     def test_alpha2digit_ordinals(self):
         source = (
-            "Cinquième troisième vingt et unième centième mille deux cent trentième."
+            "Cinquième second troisième vingt et unième centième mille deux cent trentième."
         )
-        expected = "5ème 3ème 21ème 100ème 1230ème."
+        expected = "5ème second troisième 21ème 100ème 1230ème."
         self.assertEqual(alpha2digit(source, "fr"), expected)
 
     def test_alpha2digit_decimals(self):

--- a/text_to_num/lang/english.py
+++ b/text_to_num/lang/english.py
@@ -117,7 +117,7 @@ class English(Language):
 
     AND_NUMS: Set[str] = set()
     AND = "and"
-    UNIT_ARTICLES = {"a", "an"}
+    UNIT_ARTICLES = {"one"}
 
     # Relaxed composed numbers (two-words only)
     # start => (next, target)

--- a/text_to_num/parsers.py
+++ b/text_to_num/parsers.py
@@ -301,7 +301,7 @@ class WordToDigitParser:
                         else self.int_builder.value
                     ),
                     word,
-                )
+                ) if self.int_builder.value > 3 else word
             )
             self.closed = True
         elif (


### PR DESCRIPTION
Don't convert one or second when they are used as nouns or determiners:

* one moment
* this is the one
* just one second please
* no one
* another one

But must be converted in twenty-one, thirty-second, etc…