### PR TITLE
Fix english ord2card

### DIFF
--- a/tests/test_text_to_num_en.py
+++ b/tests/test_text_to_num_en.py
@@ -128,9 +128,9 @@ class TestTextToNumEN(TestCase):
 
     def test_alpha2digit_ordinals(self):
         source = (
-            "Fifth third second twenty-first hundredth one thousand two hundred thirtieth."
+            "Fifth third second twenty-first hundredth one thousand two hundred thirtieth twenty-fifth thirty-eighth forty-ninth."
         )
-        expected = "5th third second 21st 100th 1230th."
+        expected = "5th third second 21st 100th 1230th 25th 38th 49th."
         self.assertEqual(alpha2digit(source, "en"), expected)
 
         source = (

--- a/text_to_num/lang/english.py
+++ b/text_to_num/lang/english.py
@@ -146,6 +146,12 @@ class English(Language):
             source = RAD_MAP[source]
         elif source.endswith("ie"):
             source = source[:-2] + "y"
+        elif source.endswith('fif'): # fifth -> five
+            source = source[:-1] + 've'
+        elif source.endswith('eigh'): # eighth -> eight
+            source = source + 't'
+        elif source.endswith('nin'): # ninth -> nine
+            source = source + 'e'
         if source not in self.NUMBERS:
             return None
         return source


### PR DESCRIPTION
Fix english ord2card to parse correctly ordinal numbers with units like fifth, eighth and ninth.