### PR TITLE
Added parser for German language

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         "Topic :: Text Processing :: Filters",
         "Natural Language :: French",
         "Natural Language :: English",
-        "Natural Language :: Spanish"
+        "Natural Language :: Spanish",
+		"Natural Language :: German"
     ],
     keywords="French, Spanish and English NLP words-to-numbers",
     url="https://github.com/allo-media/text2num",

--- a/tests/test_text_to_num_de.py
+++ b/tests/test_text_to_num_de.py
@@ -1,0 +1,185 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""
+Test the ``text_to_num`` library.
+"""
+from unittest import TestCase
+from text_to_num import alpha2digit, text2num
+
+
+class TestTextToNumDE(TestCase):
+    def test_text2num(self):
+        self.assertEqual(text2num("null", "de"), 0)
+
+        test1 = "dreiundfünfzig Milliarden zweihundertdreiundvierzigtausendsiebenhundertvierundzwanzig"
+        self.assertEqual(text2num(test1, "de"), 53_000_243_724)
+
+        test2 = "einundfünfzig Millionen fünfhundertachtundsiebzigtausenddreihundertzwei"
+        self.assertEqual(text2num(test2, "de"), 51_578_302)
+
+        test3 = "fünfundachtzig"
+        self.assertEqual(text2num(test3, "de"), 85)
+
+        test4 = "einundachtzig"
+        self.assertEqual(text2num(test4, "de"), 81)
+
+        self.assertEqual(text2num("fünfzehn", "de"), 15)
+        self.assertEqual(text2num("einhundertfünfzehn", "de"), 115)
+        self.assertEqual(text2num("hundertfünfzehn", "de"), 115)
+        self.assertEqual(text2num("fünfundsiebzigtausend", "de"), 75000)
+        self.assertEqual(text2num("eintausendneunhundertzwanzig", "de"), 1920)
+
+    def test_text2num_centuries(self):
+        self.assertEqual(text2num("neunzehnhundertdreiundsiebzig", "de"), 1973)
+
+    def test_text2num_exc(self):
+        self.assertRaises(ValueError, text2num, "tausendtausendzweihundert", "de")
+        self.assertRaises(ValueError, text2num, "sechzigfünfzehn", "de")
+        self.assertRaises(ValueError, text2num, "sechzighundert", "de")
+
+    def test_text2num_zeroes(self):
+        self.assertEqual(text2num("null", "de"), 0)
+        self.assertRaises(ValueError, text2num, "null acht", "de") # This is not allowed and should be solved with alpha2digit
+        self.assertRaises(ValueError, text2num, "null null hundertfünfundzwanzig", "de") # This is not allowed and should be solved with alpha2digit
+        self.assertRaises(ValueError, text2num, "fünf null", "de")
+        self.assertRaises(ValueError, text2num, "fünfzignullzwei", "de")
+        self.assertRaises(ValueError, text2num, "fünfzigdreinull", "de")
+
+    def test_alpha2digit_integers(self):
+        source = "fünfundzwanzig Kühe, zwölf Hühner und einhundertfünfundzwanzig kg Kartoffeln."
+        expected = "25 Kühe, 12 Hühner und 125 kg Kartoffeln."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+        
+        source = "Eintausendzweihundertsechsundsechzig Dollar."
+        expected = "1266 Dollar."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+        source = "eins zwei drei vier zwanzig fünfzehn"
+        expected = "1 2 3 4 20 15"
+        self.assertEqual(alpha2digit(source, "de"), expected)
+        
+        source = "einundzwanzig, einunddreißig."
+        expected = "21, 31."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+
+    def test_relaxed(self):
+        source = "eins zwei drei vier fünf und zwanzig."
+        expected = "1 2 3 4 5 und 20."
+        self.assertEqual(alpha2digit(source, "de", relaxed=True), expected)
+
+        source = "eins zwei drei vier fünfundzwanzig."
+        expected = "1 2 3 4 25."
+        self.assertEqual(alpha2digit(source, "de", relaxed=True), expected)
+
+        source = "eins zwei drei vier fünf zwanzig."
+        expected = "1 2 3 4 5 20."
+        self.assertEqual(alpha2digit(source, "de", relaxed=True), expected)
+
+        source = "vierunddreißig = vierunddreißig"
+        expected = "34 = 34"
+        self.assertEqual(alpha2digit(source, "de", relaxed=True), expected)
+
+    def test_alpha2digit_formal(self):
+        source = "plus dreiunddreißig neun sechzig null sechs zwölf einundzwanzig"
+        alpha2digit(source, "de")
+        expected = "+33 9 60 0 6 12 21"
+        self.assertEqual(alpha2digit(source, "de"), expected)
+        source = "plus dreiunddreißig neun sechzig 0 sechs zwölf einundzwanzig"
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+        source = "null neun sechzig null sechs zwölf einundzwanzig"
+        expected = "0 9 60 0 6 12 21"
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+    def test_and(self):
+        source = "fünfzig sechzig dreißig und elf"
+        expected = "50 60 30 und 11"
+        self.assertEqual(alpha2digit(source, "de"), expected)
+		
+
+    def test_alpha2digit_zero(self):
+        source = "dreizehntausend null neunzig"
+        expected = "13000 0 90"
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+        result = alpha2digit("null", "de")
+        self.assertEqual(result, "0")
+
+    def test_alpha2digit_ordinals(self):
+        # Not yet applicable to German language
+        return
+        source = (
+            " Fünfter dritter zweiter einundzwanzigster hundertster eintausendzweihundertdreißigster fünfundzwanzigster achtunddreißigster neunundvierzigster."
+        )
+        expected = "5ter third second 21st 100th 1230th 25th 38th 49th."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+        source = (
+            "first, second, third, fourth, fifth, sixth, seventh, eighth, ninth, tenth."
+        )
+        expected = "first, second, third, 4th, 5th, 6th, 7th, 8th, 9th, 10th."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+    def test_alpha2digit_decimals(self):
+        # Not yet applicable to German language
+        return
+        source = (
+            "zwölf komma neunundneunzig, einhundertzwanzig komma null fünf,"
+            " eins komma zweihundertsechsunddreißig."
+        )
+        expected = "12.99, 120.05, 1.236."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+        self.assertEqual(alpha2digit("null komma fünfzehn", "de"), "0.15")
+
+    def test_alpha2digit_signed(self):
+        source = "Es ist drinnen plus zwanzig Grad und draußen minus fünfzehn Grad."
+        expected = "Es ist drinnen +20 Grad und draußen -15 Grad."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+    def test_one_as_noun_or_article(self):
+        # Not applicable to German language
+        return
+        #source = "Ich nehme eins. Eins passt nicht!"
+        #expected = "Ich nehme eins. Eins passt nicht!"
+        #self.assertEqual(alpha2digit(source, "de"), expected)
+        #source = "No one is innocent. Another one bites the dust."
+        #self.assertEqual(alpha2digit(source, "de"), source)
+        # End of segment
+        #source = "No one. Another one. One one. Twenty one"
+        #expected = "No one. Another one. 1 1. 21"
+        #self.assertEqual(alpha2digit(source, "de"), expected)
+		
+    def test_second_as_time_unit_vs_ordinal(self):
+        # Not yet applicable to German language
+        return
+    #    source = "One second please! twenty second is parsed as twenty-second and is different from twenty seconds."
+    #    expected = "One second please! 22nd is parsed as 22nd and is different from 20 seconds."
+    #    self.assertEqual(alpha2digit(source, "de"), expected)
+
+    def test_uppercase(self):
+        source = "FÜNFZEHN EINS ZEHN EINS"
+        expected = "15 1 10 1"
+        self.assertEqual(alpha2digit(source, "de"), expected)

--- a/text_to_num/lang/__init__.py
+++ b/text_to_num/lang/__init__.py
@@ -28,6 +28,7 @@ from .base import Language  # noqa: F401
 from .french import French
 from .english import English
 from .spanish import Spanish
+from .german import German
 
 
-LANG = {"fr": French(), "en": English(), "es": Spanish()}
+LANG = {"fr": French(), "en": English(), "es": Spanish(), "de": German()}

--- a/text_to_num/lang/german.py
+++ b/text_to_num/lang/german.py
@@ -1,0 +1,256 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Dict, Optional, Set, Tuple
+
+from .base import Language
+
+
+#
+# CONSTANTS
+# Built once on import.
+#
+
+# Those words multiplies lesser numbers (see Rules)
+# Special case: "hundred" is processed apart.
+MULTIPLIERS = {
+    "tausend": 1_000,
+    "million": 1_000_000,
+    "millionen": 1_000_000,
+    "milliarde": 1_000_000_000,
+    "milliarden": 1_000_000_000,
+    "billion": 1_000_000_000_000,
+    "billionen": 1_000_000_000_000,
+    "billiarde": 1_000_000_000_000_000,
+    "billiarden": 1_000_000_000_000_000,
+    "trillion": 1_000_000_000_000_000_000,
+    "trillionen": 1_000_000_000_000_000_000,
+    "trilliarde": 1_000_000_000_000_000_000_000,
+    "trilliarden": 1_000_000_000_000_000_000_000
+}
+
+
+# Units are terminals (see Rules)
+# Special case: "zero/O" is processed apart.
+UNITS: Dict[str, int] = {
+    word: value
+    for value, word in enumerate(
+        "eins zwei drei vier fünf sechs sieben acht neun".split(), 1
+    )
+}
+# Unit variants
+UNITS["ein"] = 1
+
+# Single tens are terminals (see Rules)
+STENS: Dict[str, int] = {
+    word: value
+    for value, word in enumerate(
+        "zehn elf zwölf dreizehn vierzehn fünfzehn sechzehn siebzehn achtzehn neunzehn".split(),
+        10,
+    )
+}
+
+
+# Ten multiples
+# Ten multiples may be followed by a unit only;
+MTENS: Dict[str, int] = {
+    word: value * 10
+    for value, word in enumerate(
+        "zwanzig dreißig vierzig fünfzig sechzig siebzig achtzig neunzig".split(), 2
+    )
+}
+
+# Ten multiples that can be combined with STENS
+#MTENS_WSTENS: Set[str] = set()
+
+
+# "hundred" has a special status (see Rules)
+HUNDRED = {"hundert": 100} # einhundert?
+
+# All number words
+
+NUMBERS = MULTIPLIERS.copy()
+NUMBERS.update(UNITS)
+NUMBERS.update(STENS)
+NUMBERS.update(MTENS)
+NUMBERS.update(HUNDRED)
+#NUMBERS.update(COMPOSITES) # CIMPOSITES are already in STENS for the German language
+
+AND = "und"
+ZERO = {"null"}
+
+ALL_WORDS = list(UNITS.keys()) + list(STENS.keys()) + list(MULTIPLIERS.keys()) + list(MTENS.keys()) + list(HUNDRED.keys())+ list(ZERO) + list([AND])
+
+class German(Language):
+
+    NUMBER_DICT_GER = {
+        "null": 0,
+        "eins": 1,
+        "ein": 1,
+        "eine": 1,
+        "zwei": 2,
+        "drei": 3,
+        "vier": 4,
+        "fünf": 5,
+        "sechs": 6,
+        "sieben": 7,
+        "acht": 8,
+        "neun": 9,
+        "zehn": 10,
+        "elf": 11,
+        "zwölf": 12,
+        "dreizehn": 13,
+        "vierzehn": 14,
+        "fünfzehn": 15,
+        "sechzehn": 16,
+        "siebzehn": 17,
+        "achzehn": 18,
+        "neunzehn": 19,
+        "zwanzig": 20,
+        "dreißig": 30,
+        "vierzig": 40,
+        "fünfzig": 50,
+        "sechzig": 60,
+        "siebzig": 70,
+        "achtzig": 80,
+        "neunzig": 90,
+        "hundert": 100,
+        "tausend": 1_000,
+        "million": 1_000_000,
+        "millionen": 1_000_000,
+        "milliarde": 1_000_000_000,
+        "milliarden": 1_000_000_000,
+        "billion": 1_000_000_000_000,
+        "billionen": 1_000_000_000_000,
+        "billiarde": 1_000_000_000_000_000,
+        "billiarden": 1_000_000_000_000_000,
+        "trillion": 1_000_000_000_000_000_000,
+        "trillionen": 1_000_000_000_000_000_000,
+        "trilliarde": 1_000_000_000_000_000_000_000,
+        "trilliarden": 1_000_000_000_000_000_000_000
+    }
+
+    MULTIPLIERS = MULTIPLIERS
+    UNITS = UNITS
+    STENS = STENS
+    MTENS = MTENS
+    #MTENS_WSTENS = MTENS_WSTENS
+    HUNDRED = HUNDRED
+    NUMBERS = NUMBERS
+
+    SIGN = {"plus": "+", "minus": "-"}
+    ZERO = ZERO
+    DECIMAL_SEP = "komma"
+    DECIMAL_SYM = ","
+
+    #AND_NUMS = set(UNITS.keys()).union(set(STENS.keys()).union(set(MTENS.keys())))
+    AND = AND
+    #NEVER_IF_ALONE = {"one"} # ???
+
+    # Relaxed composed numbers (two-words only)
+    # start => (next, target)
+    #RELAXED: Dict[str, Tuple[str, str]] = {}
+
+    def ord2card(self, word: str) -> Optional[str]:
+        """Convert ordinal number to cardinal.
+
+		THIS IS STILL IN DEVELOPMENT FOR GERMAN LANGUAGE
+        
+        Return None if word is not an ordinal or is better left in letters
+        as is the case for fist and second.
+        """
+        plur_suff = word.endswith("ster") and not word.startswith("sechster") # Zwanzigster, Dreißigster, Hundertster, Tausendster ...
+        sing_suff = word.endswith("ter") # Zweiter, Vierter, Fünfter, Sechster 
+        if not (plur_suff or sing_suff):
+            if word.endswith("erster"):
+                source = word.replace("erster", "eins")
+            elif word.endswith("second"):
+                source = word.replace("dritter", "drei")
+            elif word.endswith("siebter"):
+                source = word.replace("siebter", "sieben")
+            elif word.endswith("achter"):
+                source = word.replace("achter", "acht")
+            else:
+                return None
+        else:
+            source = word[:-4] if plur_suff else word[:-3]
+        if source in MTENS.keys() or source in MULTIPLIERS.keys():
+            source = source + 'ster'
+        else:
+            source = source + 'ter'
+
+        if source not in self.NUMBERS:
+            return None
+        return source
+
+    def num_ord(self, digits: str, original_word: str) -> str:
+        """Add suffix to number in digits to make an ordinal
+		
+		THIS IS STILL IN DEVELOPMENT FOR GERMAN LANGUAGE
+		
+		"""
+        sf = original_word[-3:] if original_word.endswith("s") else original_word[-2:]
+        return f"{digits}{sf}"
+
+    def normalize(self, word: str) -> str:
+        return word
+		        
+    def split_ger(self, word: str) -> str:
+        """Splits number words into separate words, e.g. einhundertfünzig-> ein hundert fünfzig"""
+		
+        # Sort all numbers by length to start with the longest 
+        sorted_words = sorted(ALL_WORDS, key=len, reverse=True)
+        
+        current_word = ""
+        text = word.lower()
+        invalid_word = ""
+        result = ""
+        while len(text) > 0:
+            # start with the longest
+            found = False
+            for sw in sorted_words:
+				# Check at the beginning of the current sentence for the longest word in ALL_WORDS
+                if text.startswith(sw):
+                    if len(invalid_word) > 0:
+                        result += invalid_word + " "
+                        invalid_word = ""
+                        
+                    result += sw + " "
+                    text = text[len(sw):]
+                    found = True
+                    break
+            if not found:
+			
+                # current beginning could not be assigned to a word
+                if not text[0] == ' ':
+                    invalid_word += text[0:1]
+                    text = text[1:]
+                else:
+                    if len(invalid_word) > 0:
+                        result += invalid_word + " "
+                        invalid_word = ""
+                    text = text[1:]
+                    
+        if len(invalid_word) > 0:
+            result += invalid_word + " "
+    
+        return result

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -25,7 +25,9 @@ from itertools import dropwhile
 from typing import Any, Iterator, List, Sequence, Tuple
 
 from .lang import LANG
-from .parsers import WordStreamValueParser, WordToDigitParser
+from .parsers import WordStreamValueParser, WordToDigitParser, WordStreamValueParserGerman
+
+import logging
 
 
 def look_ahead(sequence: Sequence[Any]) -> Iterator[Tuple[Any, Any]]:
@@ -57,10 +59,22 @@ def text2num(text: str, lang: str, relaxed: bool = False) -> int:
     """
 
     language = LANG[lang]
-    num_parser = WordStreamValueParser(language, relaxed=relaxed)
+    
+    # The German number writing rules do not apply to the order of number processing
+    # in the commin WordStreamValueParser
+    if lang == "de":
+        # German numbers are frequently written without spaces. Split them.
+        text = language.split_ger(text)
+        num_parser = WordStreamValueParserGerman(language)
+        num_parser.parse(text)
+        return num_parser.value
+    else:
+        num_parser = WordStreamValueParser(language, relaxed=relaxed)
+        
     tokens = list(dropwhile(lambda x: x in language.ZERO, text.split()))
     if not all(num_parser.push(word, ahead) for word, ahead in look_ahead(tokens)):
         raise ValueError("invalid literal for text2num: {}".format(repr(text)))
+            
     return num_parser.value
 
 
@@ -69,34 +83,101 @@ def alpha2digit(
 ) -> str:
     """Return the text of ``text`` with all the French spelled numbers converted to digits.
     Takes care of punctuation.
+	
+	THIS IS STILL IN DEVELOOPMENT FOR GERMAN LANGUAGE
+	
     Set ``relaxed`` to True if you want to accept some disjoint numbers as compounds.
     Set ``signed`` to False if you don't want to produce signed numbers, that is, for example,
     if you prefer to get « moins 2 » instead of « -2 ».
     """
-    language = LANG[lang]
-    segments = re.split(r"\s*[\.,;\(\)…\[\]:!\?]+\s*", text)
-    punct = re.findall(r"\s*[\.,;\(\)…\[\]:!\?]+\s*", text)
-    if len(punct) < len(segments):
-        punct.append("")
-    out_segments: List[str] = []
-    for segment, sep in zip(segments, punct):
-        tokens = segment.split()
-        num_builder = WordToDigitParser(language, relaxed=relaxed, signed=signed)
-        in_number = False
-        out_tokens: List[str] = []
-        for word, ahead in look_ahead(tokens):
-            if num_builder.push(word.lower(), ahead and ahead.lower()):
-                in_number = True
-            elif in_number:
+    
+    if lang == "de":
+        language = LANG[lang]
+        segments = re.split(r"\s*[\.,;\(\)…\[\]:!\?]+\s*", text)
+        punct = re.findall(r"\s*[\.,;\(\)…\[\]:!\?]+\s*", text)
+  
+        if len(punct) < len(segments):
+            punct.append("")
+
+        out_segments: List[str] = []
+        for segment, sep in zip(segments, punct):
+
+            tokens = segment.split()
+            sentence = []
+            out_tokens: List[str] = []
+            out_tokens_is_num: List[bool] = []
+            old_num_result = None
+            token_index = 0
+
+            while token_index < len(tokens):
+                t = tokens[token_index]
+                sentence.append(t)
+                                    
+                try:
+                    num_result = text2num(" ".join(sentence), lang)
+                    old_num_result = num_result
+                    token_index += 1
+                except:
+                    # " ".join(sentence) cannot be resolved to a number
+                    
+                    # last token has to be tested again in case there is sth like "eins eins eins"
+                    # which is invalid in sum but separately allowed
+                    if not old_num_result is None:
+                        out_tokens.append(str(old_num_result))
+                        out_tokens_is_num.append(True)
+                        sentence.clear()
+                    else:
+                        out_tokens.append(t)
+                        out_tokens_is_num.append(False)
+                        sentence.clear()
+                        token_index += 1
+                    old_num_result = None
+                    
+            # any remaining tokens to add?
+            if not old_num_result is None:
+                out_tokens.append(str(old_num_result))
+                out_tokens_is_num.append(True)
+                
+            # join all and keep track on signs
+            out_segment = ""
+            for index, ot in enumerate(out_tokens):
+                if (ot in language.SIGN) and signed:
+                    if index < len(out_tokens)-1:
+                        if out_tokens_is_num[index+1] == True:
+                            out_segment += language.SIGN[ot]
+                else:
+                    out_segment +=ot + " "
+                        
+            out_segments.append(out_segment.strip())
+            out_segments.append(sep)
+        
+        
+        return "".join(out_segments)
+    else:
+        language = LANG[lang]
+        segments = re.split(r"\s*[\.,;\(\)…\[\]:!\?]+\s*", text)
+        punct = re.findall(r"\s*[\.,;\(\)…\[\]:!\?]+\s*", text)
+        if len(punct) < len(segments):
+            punct.append("")
+        out_segments: List[str] = []
+        for segment, sep in zip(segments, punct):
+            tokens = segment.split()
+            num_builder = WordToDigitParser(language, relaxed=relaxed, signed=signed)
+            in_number = False
+            out_tokens: List[str] = []
+            for word, ahead in look_ahead(tokens):
+                if num_builder.push(word.lower(), ahead and ahead.lower()):
+                    in_number = True
+                elif in_number:
+                    out_tokens.append(num_builder.value)
+                    num_builder = WordToDigitParser(language, relaxed=relaxed)
+                    in_number = num_builder.push(word.lower(), ahead and ahead.lower())
+                if not in_number:
+                    out_tokens.append(word)
+            # End of segment
+            num_builder.close()
+            if num_builder.value:
                 out_tokens.append(num_builder.value)
-                num_builder = WordToDigitParser(language, relaxed=relaxed)
-                in_number = num_builder.push(word.lower(), ahead and ahead.lower())
-            if not in_number:
-                out_tokens.append(word)
-        # End of segment
-        num_builder.close()
-        if num_builder.value:
-            out_tokens.append(num_builder.value)
-        out_segments.append(" ".join(out_tokens))
-        out_segments.append(sep)
-    return "".join(out_segments)
+            out_segments.append(" ".join(out_tokens))
+            out_segments.append(sep)
+        return "".join(out_segments)


### PR DESCRIPTION
Hi, I added a parser for German numbers. Since the structure of this language differs from the structure of Englisch or French numbers (42 -> zweiundfirzig (two and forty) -> fourty-two (forty and two)), I had to create a custom class. Ordinals and floating point numbers are not yet implemented.