### PR TITLE
Adding ptbr support

### DIFF
--- a/tests/test_text_to_num_ptbr.py
+++ b/tests/test_text_to_num_ptbr.py
@@ -1,0 +1,219 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""
+Test the ``text_to_num`` library.
+"""
+from unittest import TestCase
+from text_to_num import alpha2digit, text2num
+
+
+class TestTextToNumPT(TestCase):
+    def test_text2num(self):
+        self.assertEqual(text2num("zero", "ptbr"), 0)
+        self.assertEqual(text2num("um", "ptbr"), 1)
+        self.assertEqual(text2num("oito", "ptbr"), 8)
+        self.assertEqual(text2num("dez", "ptbr"), 10)
+        self.assertEqual(text2num("onze", "ptbr"), 11)
+        self.assertEqual(text2num("dezenove", "ptbr"), 19)
+        self.assertEqual(text2num("vinte", "ptbr"), 20)
+        self.assertEqual(text2num("vinte e um", "ptbr"), 21)
+        self.assertEqual(text2num("trinta", "ptbr"), 30)
+        self.assertEqual(text2num("trinta e um", "ptbr"), 31)
+        self.assertEqual(text2num("trinta e dois", "ptbr"), 32)
+        self.assertEqual(text2num("trinta e três", "ptbr"), 33)
+        self.assertEqual(text2num("trinta e nove", "ptbr"), 39)
+        self.assertEqual(text2num("noventa e nove", "ptbr"), 99)
+        self.assertEqual(text2num("cem", "ptbr"), 100)
+        self.assertEqual(text2num("cento e um", "ptbr"), 101)
+        self.assertEqual(text2num("duzentos", "ptbr"), 200)
+        self.assertEqual(text2num("duzentos e um", "ptbr"), 201)
+        self.assertEqual(text2num("mil", "ptbr"), 1000)
+        self.assertEqual(text2num("mil e um", "ptbr"), 1001)
+        self.assertEqual(text2num("dois mil", "ptbr"), 2000)
+        self.assertEqual(text2num("dois mil noventa e nove", "ptbr"), 2099)
+        self.assertEqual(text2num("nove mil novecentos noventa e nove", "ptbr"), 9999)
+        self.assertEqual(
+            text2num("novecentos noventa e nove mil novecentos noventa e nove", "ptbr"),
+            999999,
+        )
+
+        self.assertEqual(alpha2digit("um vírgula um", "ptbr"), "1,1")
+        self.assertEqual(alpha2digit("um vírgula quatrocentos e um", "ptbr"), "1,401")
+
+        # fail
+        #        self.assertEqual(alpha2digit("zero vírgula cinco", "ptbr"), "0,5")
+
+        #     test1 = "cincuenta y tres mil veinte millones doscientos cuarenta y tres mil setecientos veinticuatro"
+        #     self.assertEqual(text2num(test1, "ptbr"), 53_020_243_724)
+
+        #     test2 = (
+        #         "cincuenta y un millones quinientos setenta y ocho mil trescientos dos"
+        #     )
+        #     self.assertEqual(text2num(test2, "ptbr"), 51_578_302)
+
+        test3 = "oitenta e cinco"
+        self.assertEqual(text2num(test3, "ptbr"), 85)
+
+        test4 = "oitenta e um"
+        self.assertEqual(text2num(test4, "ptbr"), 81)
+
+        self.assertEqual(text2num("quinze", "ptbr"), 15)
+        self.assertEqual(text2num("cento quinze", "ptbr"), 115)
+        self.assertEqual(text2num("setenta e cinco mil", "ptbr"), 75000)
+        self.assertEqual(text2num("mil novecentos vinte", "ptbr"), 1920)
+
+    def test_text2num_exc(self):
+        self.assertRaises(ValueError, text2num, "mil mil duzentos", "ptbr")
+        self.assertRaises(ValueError, text2num, "sessenta quinze", "ptbr")
+        self.assertRaises(ValueError, text2num, "sessenta cem", "ptbr")
+
+    def test_text2num_zeroes(self):
+        self.assertEqual(text2num("zero", "ptbr"), 0)
+        self.assertEqual(text2num("zero oito", "ptbr"), 8)
+        self.assertEqual(text2num("zero zero cento vinte e cinco", "ptbr"), 125)
+        self.assertRaises(ValueError, text2num, "cinco zero", "ptbr")
+        self.assertRaises(ValueError, text2num, "cinquenta zero três", "ptbr")
+        self.assertRaises(ValueError, text2num, "cinquenta e três zero", "ptbr")
+
+    def test_alpha2digit_integers(self):
+        source = "vinte cinco vacas, doze galinhas e cento vinte e cinco kg de batatas."
+        expected = "25 vacas, 12 galinhas e 125 kg de batatas."
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "mil duzentos sessenta e seis dólares."
+        expected = "1266 dólares."
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "um dois três quatro vinte quinze"
+        expected = "1 2 3 4 20 15"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "vinte e um, trinta e um."
+        expected = "21, 31."
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_relaxed(self):
+        source = "um dois três quatro trinta e cinco."
+        expected = "1 2 3 4 35."
+        self.assertEqual(alpha2digit(source, "ptbr", relaxed=True), expected)
+
+        source = "um dois três quatro vinte, cinco."
+        expected = "1 2 3 4 20, 5."
+        self.assertEqual(alpha2digit(source, "ptbr", relaxed=True), expected)
+
+        source = "trinta e quatro = trinta quatro"
+        expected = "34 = 34"
+        self.assertEqual(alpha2digit(source, "ptbr", relaxed=True), expected)
+
+    def test_alpha2digit_formal(self):
+        source = "mais trinta e três nove sessenta zero seis doze vinte e um"
+        expected = "+33 9 60 06 12 21"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "zero nove sessenta zero seis doze vinte e um"
+        expected = "09 60 06 12 21"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_and(self):
+        source = "cinquenta sessenta trinta onze"
+        expected = "50 60 30 11"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_pt_conjunction(self):
+        source = "duzentos e quarenta e quatro"
+        expected = "244"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "dois mil e vinte"
+        expected = "2020"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "mil novecentos e oitenta e quatro"
+        expected = "1984"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "mil e novecentos"
+        expected = "1900"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "dois mil cento e vinte cinco"
+        expected = "2125"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        source = "Trezentos e setenta e oito milhões vinte e sete mil trezentos e doze"
+        expected = "378027312"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_alpha2digit_zero(self):
+        source = "treze mil zero noventa"
+        expected = "13000 090"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        self.assertEqual(alpha2digit("zero", "ptbr"), "0")
+
+    def test_alpha2digit_decimals(self):
+        source = (
+            "doze vírgula noventa e nove, cento e vinte vírgula zero cinco, "
+            "um vírgula duzentos e trinta e seis, um vírgula dois três seis."
+        )
+        expected = "12,99, 120,05, 1,236, 1,2 3 6."
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+        self.assertEqual(alpha2digit("vírgula quinze", "ptbr"), "0,15")
+        # self.assertEqual(alpha2digit("zero vírgula quinze", "ptbr"), "0,15") # TODO
+
+    def test_alpha2digit_signed(self):
+        source = "Temos mais vinte graus dentro e menos quinze fora."
+        expected = "Temos +20 graus dentro e -15 fora."
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_one_as_noun_or_article(self):
+        source = "Um momento por favor! trinta e um gatos. Um dois três quatro!"
+        expected = "Um momento por favor! 31 gatos. 1 2 3 4!"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+        # End of segment
+        source = "Nem um. Um um. Trinta e um"
+        expected = "Nem um. 1 1. 31"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_accent(self):
+        self.assertEqual(text2num("um milhao", "ptbr"), 1000000)
+        self.assertEqual(text2num("um milhão", "ptbr"), 1000000)
+        self.assertEqual(alpha2digit("Um milhao", "ptbr"), "1000000")
+        self.assertEqual(alpha2digit("Um milhão", "ptbr"), "1000000")
+
+    def test_second_as_time_unit_vs_ordinal(self):
+        source = "Um segundo por favor! Vigésimo segundo é diferente de vinte segundos."
+        expected = "Um segundo por favor! 22º é diferente de 20 segundos."
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_alpha2digit_ordinals(self):
+        source = "Ordinais: primeiro, quinto, terceiro, vigésima, vigésimo primeiro, centésimo quadragésimo quinto"
+        expected = "Ordinais: primeiro, 5º, terceiro, 20ª, 21º, 145º"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)
+
+    def test_alpha2digit_ordinals_more(self):
+        source = "A décima quarta brigada do exército português, juntamento com o nonagésimo sexto regimento britânico, bateu o centésimo vigésimo sétimo regimento de infantaria de Napoleão"
+        expected = "A 14ª brigada do exército português, juntamento com o 96º regimento britânico, bateu o 127º regimento de infantaria de Napoleão"
+        self.assertEqual(alpha2digit(source, "ptbr"), expected)

--- a/text_to_num/lang/__init__.py
+++ b/text_to_num/lang/__init__.py
@@ -29,5 +29,12 @@ from .french import French
 from .english import English
 from .spanish import Spanish
 from .portuguese import Portuguese
+from .portuguese_br import PortugueseBr
 
-LANG = {"fr": French(), "en": English(), "es": Spanish(), "pt": Portuguese()}
+LANG = {
+    "fr": French(),
+    "en": English(),
+    "es": Spanish(),
+    "pt": Portuguese(),
+    "ptbr": PortugueseBr(),
+}

--- a/text_to_num/lang/portuguese_br.py
+++ b/text_to_num/lang/portuguese_br.py
@@ -1,0 +1,365 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import re
+from typing import Dict, Optional, Set, Tuple, List
+
+from .base import Language
+
+#
+# CONSTANTS
+# Built once on import.
+#
+
+# Those words multiplies lesser numbers (see Rules)
+# Exception: "(de) milliards" that can multiply bigger numbers ("milliards de milliards")
+MULTIPLIERS = {
+    "mil": 10 ** 3,
+    "milhar": 10 ** 3,
+    "milhares": 10 ** 3,
+    "milhao": 10 ** 6,
+    "milhão": 10 ** 6,
+    "milhoes": 10 ** 6,
+    "milhões": 10 ** 6,
+    "bilhao": 10 ** 9,
+    "bilhão": 10 ** 9,
+    "bilhoes": 10 ** 9,
+    "bilhões": 10 ** 9,
+    "trilhao": 10 ** 12,
+    "trilhão": 10 ** 12,
+    "trilhoes": 10 ** 12,
+    "trilhões": 10 ** 12,
+}
+
+
+# Units are terminals (see Rules)
+UNITS: Dict[str, int] = {
+    word: value
+    for value, word in enumerate(
+        "um dois três quatro cinco seis sete oito nove".split(), 1
+    )
+}
+# Unit variants
+UNITS["uma"] = 1
+UNITS["duas"] = 2
+UNITS["catorze"] = 14
+
+# Single tens are terminals (see Rules)
+# exact find
+STENS: Dict[str, int] = {
+    word: value
+    for value, word in enumerate(
+        "dez onze doze treze quatorze quinze dezesseis dezessete dezoito dezenove".split(),
+        10,
+    )
+}
+# Stens variants
+STENS["catorze"] = 14
+
+# Ten multiples
+# Ten multiples may be followed by a unit only;
+# the number is the multiplier of the first token
+MTENS: Dict[str, int] = {
+    word: value * 10
+    for value, word in enumerate(
+        "vinte trinta quarenta cinquenta sessenta setenta oitenta noventa".split(), 2
+    )
+}
+
+# Ten multiples that can be combined with STENS
+MTENS_WSTENS: Set[str] = set()
+
+HUNDRED = {
+    "cem": 100,
+    "centena": 100,
+    "cento": 100,
+    "centenas": 100,
+    "duzentos": 200,
+    "duzentas": 200,
+    "trezentos": 300,
+    "trezentas": 300,
+    "quatrocentos": 400,
+    "quatrocentas": 400,
+    "quinhentos": 500,
+    "quinhentas": 500,
+    "seiscentos": 600,
+    "seiscentas": 600,
+    "setecentos": 700,
+    "setecentas": 700,
+    "oitocentos": 800,
+    "oitocentas": 800,
+    "novecentos": 900,
+    "novecentas": 900,
+}
+
+# Composites are tens already composed with terminals in one word.
+# Composites are terminals.
+
+COMPOSITES: Dict[str, int] = {}
+
+# All number words
+NUMBERS = MULTIPLIERS.copy()
+NUMBERS.update(UNITS)
+NUMBERS.update(STENS)
+NUMBERS.update(MTENS)
+NUMBERS.update(HUNDRED)
+NUMBERS.update(COMPOSITES)
+
+
+class PortugueseBr(Language):
+
+    ISO_CODE = "ptbr"
+    MULTIPLIERS = MULTIPLIERS
+    UNITS = UNITS
+    STENS = STENS
+    MTENS = MTENS
+    MTENS_WSTENS = MTENS_WSTENS
+    HUNDRED = HUNDRED
+    NUMBERS = NUMBERS
+    SIGN = {"mais": "+", "menos": "-"}
+    ZERO = {"zero"}
+    DECIMAL_SEP = "vírgula"
+    DECIMAL_SYM = ","
+
+    # pt conjunction rules are complex
+    # https://duvidas.dicio.com.br/como-escrever-numeros-por-extenso/
+    AND_NUMS = {
+        "um",
+        "uma",
+        "duas",
+        "dois",
+        "três",
+        "quatro",
+        "cinco",
+        "seis",
+        "sete",
+        "oito",
+        "nove",
+        "dez",
+        "onze",
+        "doze",
+        "treze",
+        "catorze",
+        "quatorze",
+        "quinze",
+        "dezesseis",
+        "dezessete",
+        "dezoito",
+        "dezenove",
+        "vinte",
+        "trinta",
+        "quarenta",
+        "cinquenta",
+        "sessenta",
+        "setenta",
+        "oitenta",
+        "noventa",
+        "cem",
+        "duzentos",
+        "trezentos",
+        "quatrocentos",
+        "quinhentos",
+        "seiscentos",
+        "setecentos",
+        "oitocentos",
+        "novecentos",
+    }
+
+    AND = "e"
+    NEVER_IF_ALONE = {"um", "uma"}
+
+    # Relaxed composed numbers (two-words only)
+    # start => (next, target)
+    RELAXED: Dict[str, Tuple[str, str]] = {}
+
+    PT_ORDINALS = {
+        "primeir": "um",
+        "segund": "dois",
+        "terceir": "três",
+        "quart": "quatro",
+        "quint": "cinco",
+        "sext": "seis",
+        "sétim": "sete",
+        "oitav": "oito",
+        "non": "nove",
+        "décim": "dez",
+        "vigésim": "vinte",
+        "trigésim": "trinta",
+        "quadragésim": "quarenta",
+        "quinquagésim": "cinquenta",
+        "sexagésim": "sessenta",
+        "septagésim": "setenta",
+        "octagésim": "oitenta",
+        "nonagésim": "noventa",
+        "centésim": "cem",
+        "ducentésim": "cem",
+        "trecentésim": "cem",
+        "quadrigentésim": "cem",
+        "quingentésim": "cem",
+        "sexgentésim": "cem",
+        "setingentésim": "cem",
+        "octigentésim": "cem",
+        "nonigentésim": "mil",
+        "milionésim": "milhão",
+    }
+
+    def ord2card(self, word: str) -> Optional[str]:
+        """Convert ordinal number to cardinal.
+
+        Return None if word is not an ordinal or is better left in letters
+        as is the case for first and second.
+        """
+
+        ord_ = self.PT_ORDINALS.get(word[:-1], None)
+        return ord_
+
+    def num_ord(self, digits: str, original_word: str) -> str:
+        """Add suffix to number in digits to make an ordinal
+
+        Portuguese language: 22° : vigésimo segundo: 20 + 2 °
+        so if there is a couple of ordinals found, only add suffix to the last one
+        """
+
+        return f"{digits}º" if original_word.endswith("o") else f"{digits}ª"
+
+    def normalize(self, word: str) -> str:
+        return word
+
+
+SEGMENT_BREAK = re.compile(r"\s*[\.,;\(\)…\[\]:!\?]+\s*")
+
+SUB_REGEXES = [
+    (re.compile(r"1\s"), "um "),
+    (re.compile(r"2\s"), "dois"),
+    (re.compile(r"\b1[\º\°]\b"), "primeiro"),
+    (re.compile(r"\b2[\º\°]\b"), "segundo"),
+    (re.compile(r"\b3[\º\°]\b"), "terceiro"),
+    (re.compile(r"\b1\ª\b"), "primeira"),
+    (re.compile(r"\b2\ª\b"), "segunda"),
+    (re.compile(r"\b3\ª\b"), "terceira"),
+]
+
+
+class OrdinalsMerger:
+    def merge_compound_ordinals_pt(self, text: str) -> str:
+        """join compound ordinal cases created by a text2num 1st pass
+
+        Example:
+                20° 7° -> 27°
+
+        Greedy pusher: push along the token stream,
+                       create a new ordinal sequence if an ordinal is found
+                       stop sequence when no more ordinals are found
+                       sum ordinal sequence
+
+        """
+
+        segments = re.split(SEGMENT_BREAK, text)
+        punct = re.findall(SEGMENT_BREAK, text)
+        if len(punct) < len(segments):
+            punct.append("")
+        out_segments = []
+        for segment, sep in zip(segments, punct):  # loop over segments
+            tokens = [t for t in segment.split(" ") if len(t) > 0]
+
+            pointer = 0
+            tokens_ = []
+            current_is_ordinal = False
+            seq = []
+
+            while pointer < len(tokens):
+                token = tokens[pointer]
+                if self.is_ordinal(token):  # found an ordinal, push into new seq
+                    current_is_ordinal = True
+                    seq.append(self.get_cardinal(token))
+                    gender = self.get_gender(token)
+                else:
+                    if current_is_ordinal is False:  # add standard token
+                        tokens_.append(token)
+                    else:  # close seq
+                        ordinal = sum(seq)
+                        tokens_.append(str(ordinal) + gender)
+                        tokens_.append(token)
+                        seq = []
+                        current_is_ordinal = False
+                pointer += 1
+
+            if current_is_ordinal is True:  # close seq for single token expressions
+                ordinal = sum(seq)
+                tokens_.append(str(ordinal) + gender)
+
+            tokens_ = self.text2num_style(tokens_)
+            segment = " ".join(tokens_) + sep
+            out_segments.append(segment)
+
+        text = "".join(out_segments)
+
+        return text
+
+    @staticmethod
+    def is_ordinal(token: str) -> bool:
+        out = False
+        if len(token) > 1 and ("º" in token or "°" in token or "ª" in token):
+            out = True
+
+        if token in [
+            "primeiro",
+            "primeira",
+            "segundo",
+            "segunda",
+            "terceiro",
+            "terceira",
+        ]:
+            out = True
+        return out
+
+    @staticmethod
+    def get_cardinal(token: str) -> int:
+        out = 0
+        try:
+            out = int(token[:-1])
+        except ValueError:
+            if token[:-1] == "primeir":
+                out = 1
+            elif token[:-1] == "segund":
+                out = 2
+            elif token[:-1] == "terceir":
+                out = 3
+        return out
+
+    @staticmethod
+    def get_gender(token: str) -> str:
+        gender = token[-1]
+        if gender == "a":
+            gender = "ª"
+        if gender == "o":
+            gender = "º"
+        return gender
+
+    @staticmethod
+    def text2num_style(tokens: List[str]) -> List[str]:
+        """convert a list of tokens to text2num_style, i.e. : 1 -> un/one/uno/um"""
+
+        for regex in SUB_REGEXES:
+            tokens = [re.sub(regex[0], regex[1], token) for token in tokens]
+
+        return tokens


### PR DESCRIPTION
I've just added support for Brazilian Portuguese covering a few different scenarios that Portuguese does not cover, such as:

"Catorze", "Dezenove", "Dezesseis".

Actually there are minor differences from Portuguese, but still when considered in a pipeline might not cover all situations.