### PR TITLE
Added Catalan: cardinals, ordinals, README examples, test_text_to_num_ca.py . mypy OK. All tests OK.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
-text2num
-========
+text2num fork with Catalan
+==========================
+
+*This text2num fork has been used to develop a full implementation for Catalan numerals (branch "Catalan").*
 
 |docs|
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,5 @@
-text2num fork with Catalan
-==========================
-
-*This text2num fork has been used to develop a full implementation for Catalan numerals (branch "Catalan").*
+text2num
+========
 
 |docs|
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ text2num
 
 ``text2num`` is a python package that provides functions and parser classes for:
 
-- Parsing of numbers expressed as words in French, English, Spanish, Portuguese and German and convert them to integer values.
+- Parsing of numbers expressed as words in French, English, Spanish, Portuguese, German and Catalan and convert them to integer values.
 - Detection of ordinal, cardinal and decimal numbers in a stream of French, English, Spanish and Portuguese words and get their decimal digit representations. NOTE: Spanish does not support ordinal numbers yet.
 - Detection of ordinal, cardinal and decimal numbers in a German text (BETA). NOTE: No support for 'relaxed=False' yet (behaves like 'True' by default).
 
@@ -115,6 +115,27 @@ German examples:
 
     >>> text2num("ein und achtzig", "de")
     81
+
+
+Catalan examples:
+
+.. code-block:: python
+
+    >>> from text_to_num import text2num
+    >>> text2num('noranta-cinc', "ca")
+    95
+
+    >>> text2num('huitanta-u', "ca")
+    81
+
+    >>> text2num('mil nou-cents noranta-nou', "ca")
+    1999
+
+    >>> text2num("cinquanta-un milions cinc-cents setanta-vuit mil tres-cents dos", "ca")
+    51578302
+
+    >>> text2num('mil mil dos-cents', "ca")
+    ValueError: invalid literal for text2num: 'mil mil dos-cents'
 
 
 Find and transcribe

--- a/README.rst
+++ b/README.rst
@@ -247,6 +247,24 @@ German (BETA, Note: 'relaxed' parameter is not supported yet and 'True' by defau
     'Pi ist 3,14 und so weiter, aber nicht 3 Komma 14 :-p'
 
 
+Catalan:
+
+.. code-block:: python
+
+    >>> from text_to_num import alpha2digit
+    >>> text = ("Huit-centes quaranta-dos pomes, vint-i-cinc gossos, mil tres cavalls, dotze mil sis-cents noranta-huit claus.\n Vuitanta-u és igual a huitanta-u.\n Nombres en sèrie: dotze quinze zero zero quatre vint cinquanta-dos cent tres cinquanta-dos trenta-u.\n Ordinals: cinquè tercera vint-i-uena centè mil dos-cents trentena.\n Decimals: dotze coma noranta-nou, cent vint coma zero cinc; però seixanta zero dos.")
+
+    >>> print(alpha2digit(text, "ca", ordinal_threshold=0))
+    842 pomes, 25 gossos, 1003 cavalls, 12698 claus.
+    81 és igual a 81.
+    Nombres en sèrie: 12 15 004 20 52 103 52 31.
+    Ordinals: 5è 3a 21a 100è 1230a.
+    Decimals: 12,99, 120,05; però 60 02.
+
+    >>> text = "Cinqué primera segona tercer vint-i-ué centena mil dos-cents trenté."
+    >>> print(alpha2digit(text, "ca", ordinal_threshold=3))
+    5é primera segona tercer 21é 100a 1230é.
+
 Read the complete documentation on `ReadTheDocs <http://text2num.readthedocs.io/>`_.
 
 Contribute

--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,6 @@ Catalan:
 
     >>> from text_to_num import alpha2digit
     >>> text = ("Huit-centes quaranta-dos pomes, vint-i-cinc gossos, mil tres cavalls, dotze mil sis-cents noranta-huit claus.\n Vuitanta-u és igual a huitanta-u.\n Nombres en sèrie: dotze quinze zero zero quatre vint cinquanta-dos cent tres cinquanta-dos trenta-u.\n Ordinals: cinquè tercera vint-i-uena centè mil dos-cents trentena.\n Decimals: dotze coma noranta-nou, cent vint coma zero cinc; però seixanta zero dos.")
-
     >>> print(alpha2digit(text, "ca", ordinal_threshold=0))
     842 pomes, 25 gossos, 1003 cavalls, 12698 claus.
     81 és igual a 81.
@@ -264,6 +263,15 @@ Catalan:
     >>> text = "Cinqué primera segona tercer vint-i-ué centena mil dos-cents trenté."
     >>> print(alpha2digit(text, "ca", ordinal_threshold=3))
     5é primera segona tercer 21é 100a 1230é.
+
+    >>> text = "Compràrem vint-i-cinc vaques, dotze gallines i cent vint-i-cinc coma quaranta kg de creïlles."
+    >>> alpha2digit(text, "ca")
+    'Compràrem 25 vaques, 12 gallines i 125,40 kg de creïlles.'
+
+    >>> text = "Fa més vint graus dins i menys quinze fora."
+    >>> alpha2digit(text, "ca")
+    'Fa +20 graus dins i -15 fora.'
+
 
 Read the complete documentation on `ReadTheDocs <http://text2num.readthedocs.io/>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 setup(
     name="text2num",
     version=VERSION,
-    description="Parse and convert numbers written in French, Spanish, English, Portuguese or German into their digit representation.",
+    description="Parse and convert numbers written in French, Spanish, English, Portuguese, German or Catalan into their digit representation.",
     long_description=readme(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -24,9 +24,10 @@ setup(
         "Natural Language :: English",
         "Natural Language :: Spanish",
         "Natural Language :: Portuguese",
-        "Natural Language :: German"
+        "Natural Language :: German",
+        "Natural Language :: Catalan"
     ],
-    keywords="French Spanish English Portuguese German NLP words-to-numbers",
+    keywords="French Spanish English Portuguese German Catalan NLP words-to-numbers",
     url="https://github.com/allo-media/text2num",
     author="Allo-Media",
     author_email="contact@allo-media.fr",

--- a/tests/test_text_to_num_ca.py
+++ b/tests/test_text_to_num_ca.py
@@ -1,0 +1,194 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""
+Test the ``text_to_num`` library.
+"""
+from unittest import TestCase
+from text_to_num import alpha2digit, text2num
+
+
+class TestTextToNumCA(TestCase):
+    def test_text2num(self):
+        test1 = "cinquanta-tres mil milions dos-cents quaranta-tres mil set-cents vint-i-quatre"
+        self.assertEqual(text2num(test1, "ca"), 53_000_243_724)
+
+        test2 = (
+            "cinquanta-un milions cinc-centes setanta-vuit mil tres-centes dues"
+        )
+        self.assertEqual(text2num(test2, "ca"), 51_578_302)
+
+        test3 = "vuitanta-cinc"
+        self.assertEqual(text2num(test3, "ca"), 85)
+
+        test4 = "huitanta-u"
+        self.assertEqual(text2num(test4, "ca"), 81)
+
+        self.assertEqual(text2num("quinze", "ca"), 15)
+        self.assertEqual(text2num("setanta cinc mil", "ca"), 75000)
+
+    def test_text2num_variants(self):
+        self.assertEqual(text2num("noranta-vuit", "ca"), 98)
+        self.assertEqual(text2num("noranta-huit", "ca"), 98)
+        self.assertEqual(text2num("setanta-vuit", "ca"), 78)
+        self.assertEqual(text2num("vuitanta-vuit", "ca"), 88)
+        self.assertEqual(text2num("huitanta-huit", "ca"), 88)
+        self.assertEqual(text2num("vuitanta-una", "ca"), 81)
+        self.assertEqual(text2num("vuitanta", "ca"), 80)
+        self.assertEqual(text2num("mil nou-cents vint", "ca"), 1920)
+
+#    No equivalent in Catalan
+#    def test_text2num_centuries(self):
+#        self.assertEqual(text2num("dix-neuf cent soixante-treize", "fr"), 1973)
+
+    def test_text2num_exc(self):
+        self.assertRaises(ValueError, text2num, "mil mil dos-cents", "ca")
+#        self.assertRaises(ValueError, text2num, "soixante quinze cent", "ca") #No equivalent in Catalan
+
+    def test_text2num_zeroes(self):
+        self.assertEqual(text2num("zero", "ca"), 0)
+        self.assertEqual(text2num("zero vuit", "ca"), 8)
+        self.assertEqual(text2num("zero zero cent vint-i-cinc", "ca"), 125)
+        self.assertRaises(ValueError, text2num, "cinc zero", "ca")
+        self.assertRaises(ValueError, text2num, "cinquanta zero tres", "ca")
+        self.assertRaises(ValueError, text2num, "cinquanta tres zero", "ca")
+
+    def test_alpha2digit_integers(self):
+        source = (
+            "Vint-i-cinc vaques, dotze pollastres i cent vint-i-cinc kg de creïlles."
+        )
+        expected = "25 vaques, 12 pollastres i 125 kg de creïlles."
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+        source = "Mil dos-cents seixanta-sis claus."
+        expected = "1266 claus."
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+#        source = "Mille deux cents soixante-six clous."
+#        self.assertEqual(alpha2digit(source, "fr"), expected)
+
+        source = "Vuitanta-cinc = huitanta-cinc"
+        expected = "85 = 85"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+#        source = "Nonante cinq = quatre-vingt quinze"
+#        self.assertEqual(alpha2digit(source, "fr"), expected)
+
+        source = "un dos tres quatre vint quinze"
+        expected = "1 2 3 4 20 15"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+        source = "Vint-i-u, trenta-u."
+        expected = "21, 31."
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+#   No equivalent in Catalan
+    # def test_relaxed(self):
+    #     source = "un deux trois quatre vingt quinze."
+    #     expected = "1 2 3 95."
+    #     self.assertEqual(alpha2digit(source, "fr", relaxed=True), expected)
+
+    #     source = "Quatre, vingt, quinze, quatre-vingts."
+    #     expected = "4, 20, 15, 80."
+    #     self.assertEqual(alpha2digit(source, "fr", relaxed=True), expected)
+
+    #     source = "trente-quatre = trente quatre"
+    #     expected = "34 = 34"
+    #     self.assertEqual(alpha2digit(source, "fr"), expected)
+
+    def test_alpha2digit_formal(self):
+        source = "més trenta-tres nou seixanta zero sis dotze vint-i-u"
+        expected = "+33 9 60 06 12 21"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+        source = "zero nou seixanta zero sis dotze vint-i-u"
+        expected = "09 60 06 12 21"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+    def test_trente_et_onze(self):
+        source = "cinquanta seixanta trenta i onze"
+        expected = "50 60 30 i 11"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+    def test_alpha2digit_zero(self):
+        source = "tretze mil zero noranta"
+        expected = "13000 090"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+        source = "tretze mil zero huitanta"
+        expected = "13000 080"
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+        # source = "Votre service est zéro !"
+        # self.assertEqual(alpha2digit(source, "fr"), source)
+
+        self.assertEqual(alpha2digit("zero", "ca"), "0")
+
+    def test_alpha2digit_ordinals(self):
+        source = (
+            "Cinquè primer segon tercer vint-i-unè centè mil dos-cents trentè."
+        )
+        expected = "5è primer segon tercer 21è 100è 1230è."
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+    def test_alpha2digit_all_ordinals(self):
+        source = (
+            "Cinquè primer segon tercer vint-i-unè centè mil dos-cents trentè."
+        )
+        expected = "5è 1r 2n 3r 21è 100è 1230è."
+        self.assertEqual(alpha2digit(source, "ca", ordinal_threshold=0), expected)
+
+    def test_alpha2digit_decimals(self):
+        source = (
+            "Dotze coma noranta-nou, cent vint coma zero cinc,"
+            " u coma dos-cents trenta-sis."
+        )
+        expected = "12,99, 120,05, 1,236."
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+    def test_alpha2digit_signed(self):
+        source = (
+            "Fa més vint graus a l'interior i menys quinze a l'exterior."
+        )
+        expected = "Fa +20 graus a l'interior i -15 a l'exterior."
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+        source = "Menys tres al jardí, i ja no més dos."
+        expected = "Menys 3 al jardí, i ja no més 2."
+
+        self.assertEqual(alpha2digit(source, "ca", signed=False), expected)
+        self.assertNotEqual(alpha2digit(source, "ca", signed=True), expected)
+
+    def test_article(self):
+        source = (
+            "No confondre un article o un nom amb una xifra i viceversa: "
+            "els uns i els altres; una seqüència de xifres: un, dos, tres!"
+        )
+        expected = (
+            "No confondre un article o un nom amb una xifra i viceversa: "
+            "els uns i els altres; una seqüència de xifres: 1, 2, 3!"
+        )
+        self.assertEqual(alpha2digit(source, "ca"), expected)
+
+    def test_un_pronoun(self):
+        source = "Només en vull un. Anuncie: l'un"
+        self.assertEqual(alpha2digit(source, "ca"), source)

--- a/text_to_num/lang/__init__.py
+++ b/text_to_num/lang/__init__.py
@@ -30,6 +30,7 @@ from .english import English
 from .spanish import Spanish
 from .portuguese import Portuguese
 from .german import German
+from .catalan import Catalan
 
 LANG = {
     "fr": French(),
@@ -37,4 +38,5 @@ LANG = {
     "es": Spanish(),
     "pt": Portuguese(),
     "de": German(),
+    "ca": Catalan(),
 }

--- a/text_to_num/lang/catalan.py
+++ b/text_to_num/lang/catalan.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Set, Tuple
 
 from .base import Language
 
@@ -94,7 +94,7 @@ MTENS: Dict[str, int] = {
 MTENS["huitanta"] = 80 #Valencian dialects
 
 # Ten multiples that can be combined with STENS
-MTENS_WSTENS = {}
+MTENS_WSTENS: Set[str] = set() # {}
 
 
 # "cent" has a special status (see Rules)
@@ -212,13 +212,13 @@ class Catalan(Language):
     DECIMAL_SEP = "coma"
     DECIMAL_SYM = ","
 
-    AND_NUMS = {}
+    AND_NUMS: Set[str] = set() #{}
     AND = "i"
     NEVER_IF_ALONE = {"u", "un", "una"}
 
     # Relaxed composed numbers (two-words only)
     # start => (next, target)
-    RELAXED = {}
+    RELAXED: Dict[str, Tuple[str, str]] = {}
 
     def ord2card(self, word: str) -> Optional[str]:
         """Convert ordinal number to cardinal.
@@ -237,7 +237,7 @@ class Catalan(Language):
             source = word[:-4]
         elif sing_masc_suff:
             source = word[:-1]
-        else: #plur_masc_suff, sing_fem_suff
+        else: # if plur_masc_suff or sing_fem_suff:
             source = word[:-3]
         if source == "cinqu": #5
             source = "cinc"
@@ -273,7 +273,7 @@ class Catalan(Language):
             return f"{digits}ns"
         elif original_word.endswith("a"): #fem. sing.
             return f"{digits}a"
-        elif original_word.endswith("es"): #fem. plur.
+        else: # if original_word.endswith("es"): #fem. plur.
             return f"{digits}es"
 
     def normalize(self, word: str) -> str:

--- a/text_to_num/lang/catalan.py
+++ b/text_to_num/lang/catalan.py
@@ -103,23 +103,24 @@ HUNDRED = {
     "cent": 100,
 #    "cents": 100,
     "dos-cents": 200,
-    "dos-centes": 200,
+    "dos-centes": 200, #feminine
+    "dues-centes": 200, #feminine alternative
     "tres-cents": 300,
-    "tres-centes": 300,
+    "tres-centes": 300, #feminine
     "quatre-cents": 400,
-    "quatre-centes": 400,
+    "quatre-centes": 400, #feminine
     "cinc-cents": 500,
-    "cinc-centes": 500,
+    "cinc-centes": 500, #feminine
     "sis-cents": 600,
-    "sis-centes": 600,
+    "sis-centes": 600, #feminine
     "set-cents": 700,
-    "set-centes": 700,
-    "huit-cents": 800,
-    "huit-centes": 800,
+    "set-centes": 700, #feminine
+    "huit-cents": 800, #Valencian dialects
+    "huit-centes": 800, #Valencian dialects #feminine
     "vuit-cents": 800,
-    "vuit-centes": 800,
+    "vuit-centes": 800, #feminine
     "nou-cents": 900,
-    "nou-centes": 900,
+    "nou-centes": 900, #feminine
 }
 
 

--- a/text_to_num/lang/catalan.py
+++ b/text_to_num/lang/catalan.py
@@ -101,7 +101,8 @@ MTENS_WSTENS = {}
 # 100, 200, ..., 900
 HUNDRED = {
     "cent": 100,
-#    "cents": 100,
+    # "cents": 100,
+    # "centes": 100,
     "dos-cents": 200,
     "dos-centes": 200, #feminine
     "dues-centes": 200, #feminine alternative
@@ -159,11 +160,41 @@ NUMBERS.update(COMPOSITES)
 
 IRR_ORD = {
     "primer": ("un", "1r"),
-#    "primera": ("un", "1a"),
+    "primera": ("un", "1a"),
+    "primers": ("un", "1rs"),
+    "primeres": ("un", "1es"),
     "segon": ("dos", "2n"),
-#    "segona": ("dos", "2a"),
+    "segona": ("dos", "2a"),
+    "segons": ("dos", "2ns"),
+    "segones": ("dos", "2es"),
     "tercer": ("tres", "3r"),
+    "tercera": ("tres", "3a"),
+    "tercers": ("tres", "3rs"),
+    "terceres": ("tres", "3es"),
     "quart": ("quatre", "4t"),
+    "quarta": ("quatre", "4a"),
+    "quarts": ("quatre", "4ts"),
+    "quartes": ("quatre", "4es"),
+    "quint": ("cinc", "5è"),
+    "quinta": ("cinc", "5a"),
+    "quints": ("cinc", "5ns"),
+    "quintes": ("cinc", "5es"),
+    "sext": ("sis", "6è"),
+    "sexta": ("sis", "6a"),
+    "sexts": ("sis", "6ns"),
+    "sextes": ("sis", "6es"),
+    "sèptim": ("set", "7è"),
+    "sèptima": ("set", "7a"),
+    "sèptims": ("set", "7ns"),
+    "sèptimes": ("set", "7es"),
+    "octau": ("vuit", "8è"),
+    "octava": ("vuit", "8a"),
+    "octaus": ("vuit", "8ns"),
+    "octaves": ("vuit", "8es"),
+    "dècim": ("deu", "10è"),
+    "dècima": ("deu", "10a"),
+    "dècims": ("deu", "10ns"),
+    "dècimes": ("deu", "10es"),
 }
 
 class Catalan(Language):
@@ -189,19 +220,61 @@ class Catalan(Language):
     # start => (next, target)
     RELAXED = {}
 
-    # TODO
     def ord2card(self, word: str) -> Optional[str]:
         """Convert ordinal number to cardinal.
 
-        Return None if word is not an ordinal or is better left in letters
-        as is the case for fist and second.
+        Return None if word is not an ordinal or is better left in letters.
         """
-        return None
+        if word in IRR_ORD:
+            return IRR_ORD[word][0]
+        plur_masc_suff = word.endswith("ens")
+        plur_fem_suff = word.endswith("enes")
+        sing_masc_suff = word.endswith("è") or word.endswith("é") # dialectal variant
+        sing_fem_suff = word.endswith("ena")
+        if not (plur_masc_suff or plur_fem_suff or sing_masc_suff or sing_fem_suff):
+            return None
+        if plur_fem_suff:
+            source = word[:-4]
+        elif sing_masc_suff:
+            source = word[:-1]
+        else: #plur_masc_suff, sing_fem_suff
+            source = word[:-3]
+        if source == "cinqu": #5
+            source = "cinc"
+        elif source == "nov": #9
+            source = "nou"
+        elif source == "des": #10
+            source = "deu"
+        elif source == "dihuit": #18
+            source = "díhuit"
+        elif source == "deneu": #19
+            source = "dèneu"
+        elif source == "milion": #1000000  # TODO: Fix "un milioné"->"1000000é"
+            source = "milió"
+        elif source not in self.NUMBERS:
+            source = source + "e" #11, 12, ..., 16
+            if source not in self.NUMBERS:
+                source = source[:-1] + "a" #30, 40, ..., 90
+                if source not in self.NUMBERS:
+                    source = source[:-1] + "s" #200, 300, ..., 900
+                    if source not in self.NUMBERS:
+                        return None
+        return source
 
-    # TODO
     def num_ord(self, digits: str, original_word: str) -> str:
         """Add suffix to number in digits to make an ordinal"""
-        return f"{digits}º" if original_word.endswith("o") else f"{digits}ª"
+        if original_word in IRR_ORD:
+            return IRR_ORD[original_word][1]
+        elif original_word.endswith("è"): #masc. sing.
+            return f"{digits}è"
+        elif original_word.endswith("é"): #masc. sing. dialectal variant
+            return f"{digits}é"
+        elif original_word.endswith("ns"): #masc. plur.
+            return f"{digits}ns"
+        elif original_word.endswith("a"): #fem. sing.
+            return f"{digits}a"
+        elif original_word.endswith("es"): #fem. plur.
+            return f"{digits}es"
 
     def normalize(self, word: str) -> str:
         return word

--- a/text_to_num/lang/catalan.py
+++ b/text_to_num/lang/catalan.py
@@ -1,0 +1,206 @@
+# MIT License
+
+# Copyright (c) 2018-2019 Groupe Allo-Media
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Dict, Optional
+
+from .base import Language
+
+#
+# CONSTANTS
+# Built once on import.
+#
+
+# Those words multiplies lesser numbers (see Rules)
+# Special case: "cent" is processed apart.
+MULTIPLIERS = {
+    "mil": 1000,
+#    "miler": 1000,
+#    "milers": 1000,
+    "milió": 1000000,
+    "milions": 1000000,
+    "miliard": 1000000000,
+    "miliards": 1000000000,
+    "bilió": 1000000000000,
+    "bilions": 1000000000000,
+    "trilió": 1000000000000000000,
+    "trilions": 1000000000000000000,
+}
+
+
+# Units are terminals (see Rules)
+# Special case: "zero" is processed apart.
+# 1, 2, ..., 9
+UNITS: Dict[str, int] = {
+    word: value
+    for value, word in enumerate(
+        "un dos tres quatre cinc sis set vuit nou".split(), 1
+    )
+}
+# Unit variants
+UNITS["u"] = 1     #standard variant
+UNITS["una"] = 1   #feminine
+UNITS["dues"] = 2  #feminine
+UNITS["huit"] = 8  #Valencian dialects
+
+
+# Single tens are terminals (see Rules)
+# 10, 11, ..., 19
+STENS: Dict[str, int] = {
+    word: value
+    for value, word in enumerate(
+        "deu onze dotze tretze catorze quinze setze disset divuit dinou".split(),
+        10,
+    )
+}
+# Variants
+STENS["desset"] = 17 #dialectal variant
+STENS["dèsset"] = 17 #Valencian dialects
+STENS["devuit"] = 18 #dialectal variant
+STENS["díhuit"] = 18 #Valencian dialects
+STENS["dèneu"] = 19  #Valencian dialects
+STENS["denou"] = 19  #dialectal variant
+STENS["dènou"] = 19  #dialectal variant
+
+
+# Ten multiples
+# Ten multiples may be followed by a unit only;
+# 20, 30, ..., 90
+MTENS: Dict[str, int] = {
+    word: value * 10
+    for value, word in enumerate(
+        "vint trenta quaranta cinquanta seixanta setanta vuitanta noranta".split(), 2
+    )
+}
+# Variants
+MTENS["huitanta"] = 80 #Valencian dialects
+
+# Ten multiples that can be combined with STENS
+MTENS_WSTENS = {}
+
+
+# "cent" has a special status (see Rules)
+# 100, 200, ..., 900
+HUNDRED = {
+    "cent": 100,
+#    "cents": 100,
+    "dos-cents": 200,
+    "dos-centes": 200,
+    "tres-cents": 300,
+    "tres-centes": 300,
+    "quatre-cents": 400,
+    "quatre-centes": 400,
+    "cinc-cents": 500,
+    "cinc-centes": 500,
+    "sis-cents": 600,
+    "sis-centes": 600,
+    "set-cents": 700,
+    "set-centes": 700,
+    "huit-cents": 800,
+    "huit-centes": 800,
+    "vuit-cents": 800,
+    "vuit-centes": 800,
+    "nou-cents": 900,
+    "nou-centes": 900,
+}
+
+
+# Composites are tens already composed with terminals in one word.
+# Composites are terminals.
+
+#31, 32, ..., 41, 42..., 91, 92... 99
+COMPOSITES: Dict[str, int] = {
+    "-".join((ten_word, unit_word)): ten_val + unit_val
+    for ten_word, ten_val in MTENS.items()
+    for unit_word, unit_val in UNITS.items()
+    if 20 < ten_val <= 90
+}
+
+#21, 22, ..., 29
+COMPOSITES.update(
+    {
+        "-".join((ten_word, et_word)): ten_val + et_val
+        for ten_word, ten_val in MTENS.items()
+        for et_word, et_val in (("i-u", 1), ("i-un", 1), ("i-una", 1),
+        ("i-dos", 2), ("i-dues", 2), ("i-tres", 3), ("i-quatre", 4),
+        ("i-cinc", 5), ("i-sis", 6), ("i-set", 7), ("i-huit", 8),
+        ("i-vuit", 8),("i-nou", 9))
+        if ten_val == 20
+    }
+)
+
+# All number words
+
+NUMBERS = MULTIPLIERS.copy()
+NUMBERS.update(UNITS)
+NUMBERS.update(STENS)
+NUMBERS.update(MTENS)
+NUMBERS.update(HUNDRED)
+NUMBERS.update(COMPOSITES)
+
+IRR_ORD = {
+    "primer": ("un", "1r"),
+#    "primera": ("un", "1a"),
+    "segon": ("dos", "2n"),
+#    "segona": ("dos", "2a"),
+    "tercer": ("tres", "3r"),
+    "quart": ("quatre", "4t"),
+}
+
+class Catalan(Language):
+
+    MULTIPLIERS = MULTIPLIERS
+    UNITS = UNITS
+    STENS = STENS
+    MTENS = MTENS
+    MTENS_WSTENS = MTENS_WSTENS
+    HUNDRED = HUNDRED
+    NUMBERS = NUMBERS
+
+    SIGN = {"més": "+", "menys": "-"}
+    ZERO = {"zero"}
+    DECIMAL_SEP = "coma"
+    DECIMAL_SYM = ","
+
+    AND_NUMS = {}
+    AND = "i"
+    NEVER_IF_ALONE = {"u", "un", "una"}
+
+    # Relaxed composed numbers (two-words only)
+    # start => (next, target)
+    RELAXED = {}
+
+    # TODO
+    def ord2card(self, word: str) -> Optional[str]:
+        """Convert ordinal number to cardinal.
+
+        Return None if word is not an ordinal or is better left in letters
+        as is the case for fist and second.
+        """
+        return None
+
+    # TODO
+    def num_ord(self, digits: str, original_word: str) -> str:
+        """Add suffix to number in digits to make an ordinal"""
+        return f"{digits}º" if original_word.endswith("o") else f"{digits}ª"
+
+    def normalize(self, word: str) -> str:
+        return word

--- a/text_to_num/lang/catalan.py
+++ b/text_to_num/lang/catalan.py
@@ -33,8 +33,8 @@ from .base import Language
 # Special case: "cent" is processed apart.
 MULTIPLIERS = {
     "mil": 1000,
-#    "miler": 1000,
-#    "milers": 1000,
+    # "miler": 1000,
+    # "milers": 1000,
     "milió": 1000000,
     "milions": 1000000,
     "miliard": 1000000000,
@@ -56,10 +56,10 @@ UNITS: Dict[str, int] = {
     )
 }
 # Unit variants
-UNITS["u"] = 1     #standard variant
-UNITS["una"] = 1   #feminine
-UNITS["dues"] = 2  #feminine
-UNITS["huit"] = 8  #Valencian dialects
+UNITS["u"] = 1     # standard variant
+UNITS["una"] = 1   # feminine
+UNITS["dues"] = 2  # feminine
+UNITS["huit"] = 8  # Valencian dialects
 
 
 # Single tens are terminals (see Rules)
@@ -72,13 +72,13 @@ STENS: Dict[str, int] = {
     )
 }
 # Variants
-STENS["desset"] = 17 #dialectal variant
-STENS["dèsset"] = 17 #Valencian dialects
-STENS["devuit"] = 18 #dialectal variant
-STENS["díhuit"] = 18 #Valencian dialects
-STENS["dèneu"] = 19  #Valencian dialects
-STENS["denou"] = 19  #dialectal variant
-STENS["dènou"] = 19  #dialectal variant
+STENS["desset"] = 17  # dialectal variant
+STENS["dèsset"] = 17  # Valencian dialects
+STENS["devuit"] = 18  # dialectal variant
+STENS["díhuit"] = 18  # Valencian dialects
+STENS["dèneu"] = 19   # Valencian dialects
+STENS["denou"] = 19   # dialectal variant
+STENS["dènou"] = 19   # dialectal variant
 
 
 # Ten multiples
@@ -91,10 +91,10 @@ MTENS: Dict[str, int] = {
     )
 }
 # Variants
-MTENS["huitanta"] = 80 #Valencian dialects
+MTENS["huitanta"] = 80  # Valencian dialects
 
 # Ten multiples that can be combined with STENS
-MTENS_WSTENS: Set[str] = set() # {}
+MTENS_WSTENS: Set[str] = set()  # {}
 
 
 # "cent" has a special status (see Rules)
@@ -104,31 +104,31 @@ HUNDRED = {
     # "cents": 100,
     # "centes": 100,
     "dos-cents": 200,
-    "dos-centes": 200, #feminine
-    "dues-centes": 200, #feminine alternative
+    "dos-centes": 200,  # feminine
+    "dues-centes": 200,  # feminine alternative
     "tres-cents": 300,
-    "tres-centes": 300, #feminine
+    "tres-centes": 300,  # feminine
     "quatre-cents": 400,
-    "quatre-centes": 400, #feminine
+    "quatre-centes": 400,  # feminine
     "cinc-cents": 500,
-    "cinc-centes": 500, #feminine
+    "cinc-centes": 500,  # feminine
     "sis-cents": 600,
-    "sis-centes": 600, #feminine
+    "sis-centes": 600,  # feminine
     "set-cents": 700,
-    "set-centes": 700, #feminine
-    "huit-cents": 800, #Valencian dialects
-    "huit-centes": 800, #Valencian dialects #feminine
+    "set-centes": 700,  # feminine
+    "huit-cents": 800,  # Valencian dialects
+    "huit-centes": 800,  # Valencian dialects #feminine
     "vuit-cents": 800,
-    "vuit-centes": 800, #feminine
+    "vuit-centes": 800,  # feminine
     "nou-cents": 900,
-    "nou-centes": 900, #feminine
+    "nou-centes": 900,  # feminine
 }
 
 
 # Composites are tens already composed with terminals in one word.
 # Composites are terminals.
 
-#31, 32, ..., 41, 42..., 91, 92... 99
+# 31, 32, ..., 41, 42..., 91, 92... 99
 COMPOSITES: Dict[str, int] = {
     "-".join((ten_word, unit_word)): ten_val + unit_val
     for ten_word, ten_val in MTENS.items()
@@ -136,15 +136,16 @@ COMPOSITES: Dict[str, int] = {
     if 20 < ten_val <= 90
 }
 
-#21, 22, ..., 29
+# 21, 22, ..., 29
 COMPOSITES.update(
     {
         "-".join((ten_word, et_word)): ten_val + et_val
         for ten_word, ten_val in MTENS.items()
-        for et_word, et_val in (("i-u", 1), ("i-un", 1), ("i-una", 1),
-        ("i-dos", 2), ("i-dues", 2), ("i-tres", 3), ("i-quatre", 4),
-        ("i-cinc", 5), ("i-sis", 6), ("i-set", 7), ("i-huit", 8),
-        ("i-vuit", 8),("i-nou", 9))
+        for et_word, et_val in (
+            ("i-u", 1), ("i-un", 1), ("i-una", 1),
+            ("i-dos", 2), ("i-dues", 2), ("i-tres", 3), ("i-quatre", 4),
+            ("i-cinc", 5), ("i-sis", 6), ("i-set", 7), ("i-huit", 8),
+            ("i-vuit", 8), ("i-nou", 9))
         if ten_val == 20
     }
 )
@@ -197,6 +198,7 @@ IRR_ORD = {
     "dècimes": ("deu", "10es"),
 }
 
+
 class Catalan(Language):
 
     MULTIPLIERS = MULTIPLIERS
@@ -212,7 +214,7 @@ class Catalan(Language):
     DECIMAL_SEP = "coma"
     DECIMAL_SYM = ","
 
-    AND_NUMS: Set[str] = set() #{}
+    AND_NUMS: Set[str] = set()  # {}
     AND = "i"
     NEVER_IF_ALONE = {"u", "un", "una"}
 
@@ -229,7 +231,7 @@ class Catalan(Language):
             return IRR_ORD[word][0]
         plur_masc_suff = word.endswith("ens")
         plur_fem_suff = word.endswith("enes")
-        sing_masc_suff = word.endswith("è") or word.endswith("é") # dialectal variant
+        sing_masc_suff = word.endswith("è") or word.endswith("é")  # dialectal variant
         sing_fem_suff = word.endswith("ena")
         if not (plur_masc_suff or plur_fem_suff or sing_masc_suff or sing_fem_suff):
             return None
@@ -237,26 +239,26 @@ class Catalan(Language):
             source = word[:-4]
         elif sing_masc_suff:
             source = word[:-1]
-        else: # if plur_masc_suff or sing_fem_suff:
+        else:  # if plur_masc_suff or sing_fem_suff:
             source = word[:-3]
-        if source == "cinqu": #5
+        if source == "cinqu":  # 5
             source = "cinc"
-        elif source == "nov": #9
+        elif source == "nov":  # 9
             source = "nou"
-        elif source == "des": #10
+        elif source == "des":  # 10
             source = "deu"
-        elif source == "dihuit": #18
+        elif source == "dihuit":  # 18 Valencian variant
             source = "díhuit"
-        elif source == "deneu": #19
+        elif source == "deneu":  # 19 Valencian variant
             source = "dèneu"
-        elif source == "milion": #1000000  # TODO: Fix "un milioné"->"1000000é"
+        elif source == "milion":  # 1000000  # TODO: Fix "un milioné"->"1000000é"
             source = "milió"
         elif source not in self.NUMBERS:
-            source = source + "e" #11, 12, ..., 16
+            source = source + "e"  # 11, 12, ..., 16
             if source not in self.NUMBERS:
-                source = source[:-1] + "a" #30, 40, ..., 90
+                source = source[:-1] + "a"  # 30, 40, ..., 90
                 if source not in self.NUMBERS:
-                    source = source[:-1] + "s" #200, 300, ..., 900
+                    source = source[:-1] + "s"  # 200, 300, ..., 900
                     if source not in self.NUMBERS:
                         return None
         return source
@@ -265,15 +267,15 @@ class Catalan(Language):
         """Add suffix to number in digits to make an ordinal"""
         if original_word in IRR_ORD:
             return IRR_ORD[original_word][1]
-        elif original_word.endswith("è"): #masc. sing.
+        elif original_word.endswith("è"):  # masc. sing.
             return f"{digits}è"
-        elif original_word.endswith("é"): #masc. sing. dialectal variant
+        elif original_word.endswith("é"):  # masc. sing. dialectal variant
             return f"{digits}é"
-        elif original_word.endswith("ns"): #masc. plur.
+        elif original_word.endswith("ns"):  # masc. plur.
             return f"{digits}ns"
-        elif original_word.endswith("a"): #fem. sing.
+        elif original_word.endswith("a"):  # fem. sing.
             return f"{digits}a"
-        else: # if original_word.endswith("es"): #fem. plur.
+        else:  # if original_word.endswith("es"):  # fem. plur.
             return f"{digits}es"
 
     def normalize(self, word: str) -> str:


### PR DESCRIPTION
Added Catalan: cardinals, ordinals, README examples, test_text_to_num_ca.py . mypy OK. All tests OK.

Covers dialectal variants (central Catalan, Valencian, Balearic...).

I've tried to follow all the instructions in https://text2num.readthedocs.io/en/stable/contribute.html

PR made from dedicated branch "Catalan" in my fork.

Please let me know should anything else be necessary.