### PR TITLE
fixed a bug in German ordinal detection

### DIFF
--- a/text_to_num/lang/german.py
+++ b/text_to_num/lang/german.py
@@ -211,7 +211,7 @@ class German(Language):
             if not found:
                 # is (large) ordinal ending?
                 ord_match = None
-                if len(result) > 3 and text.startswith("ste"):
+                if not invalid_word and len(result) > 3 and text.startswith("ste"):
                     ord_match = re.search(self.LARGE_ORDINAL_SUFFIXES_GER, text)
 
                 if ord_match:


### PR DESCRIPTION
I realized there was a bug inside the function `split_number_word` for the German parser related to the detection of ordinal numbers. For example the word `einkaufsliste` (shopping-list) became "1" because the parser saw "ein" (one) and falsely assumed "...iste" was the ending of an (unknown) ordinal number.
I fixed the bug by making sure that the ordinal indicator "iste" actually follows a known number.