### PR TITLE
[de] fix: False positive ordinal detection

### DIFF
--- a/tests/test_text_to_num_de.py
+++ b/tests/test_text_to_num_de.py
@@ -297,3 +297,12 @@ class TestTextToNumDE(TestCase):
         source = "FÜNFZEHN EINS ZEHN EINS"
         expected = "15 1 10 1"
         self.assertEqual(alpha2digit(source, "de"), expected)
+
+    def test_ordinals_false_positives(self):
+        source = "In zehnten Jahrzehnten. Und einmal mit den Vereinten."
+        expected = "In 10. Jahrzehnten. Und einmal mit den Vereinten."
+        self.assertEqual(alpha2digit(source, "de"), expected)
+
+        source = "Dies ist eine Liste oder die Einkaufsliste."
+        expected = source
+        self.assertEqual(alpha2digit(source, "de"), expected)

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -258,6 +258,13 @@ def _alpha2digit_agg(
                         # finish LAST group but keep token_index
                         token_to_add = str(combined_num_result)
                         token_to_add_is_num = True
+                elif tmp_token_ordinal_org is not None:
+                    # revert ordinal
+                    sentence[len(sentence) - 1] = str(tmp_token_ordinal_org)
+                    token_index += 1
+                    token_to_add = " ".join(sentence)
+                    token_to_add_is_num = False
+                    current_token_ordinal_org = None
                 else:
                     # previous text was not a valid number
                     # prep. for next group


### PR DESCRIPTION
I found a bug with German words ending with ordinals. Those ordinals got replaced by the ordinal without its suffix. E.g. "Jahrzehnten" (decades) becomes "jahrzehn". 
To restore the case, I restored the whole token.
Because its symptoms were similar to #89, I added test cases for both issues.