### PR TITLE
[DE] fix hundred addition

### DIFF
--- a/tests/test_text_to_num_de.py
+++ b/tests/test_text_to_num_de.py
@@ -84,6 +84,11 @@ class TestTextToNumDE(TestCase):
         self.assertRaises(ValueError, text2num, "fünfzignullzwei", "de")
         self.assertRaises(ValueError, text2num, "fünfzigdreinull", "de")
 
+    def test_text2num_hundred_addition(self):
+        self.assertRaises(ValueError, text2num, "achtundachtzig dreihundert", "de")
+        self.assertRaises(ValueError, text2num, "zwanzig dreihundert", "de")
+        self.assertRaises(ValueError, text2num, "zwei zwölfhundert", "de")
+
     def test_alpha2digit_integers(self):
         source = "fünfundzwanzig Kühe, zwölf Hühner und einhundertfünfundzwanzig kg Kartoffeln."
         expected = "25 Kühe, 12 Hühner und 125 kg Kartoffeln."

--- a/text_to_num/parsers.py
+++ b/text_to_num/parsers.py
@@ -346,6 +346,8 @@ class WordStreamValueParserGerman(WordStreamValueParserInterface):
                 elif (ng[hundred_index - 1] in self.lang.UNITS) or (
                     ng[hundred_index - 1] in self.lang.STENS
                 ):
+                    if hundred_index - 2 >= 0 and ng[hundred_index - 2] not in self.lang.MULTIPLIERS:
+                        raise ValueError("invalid {} without multiplier: {}".format(STATIC_HUNDRED, repr(ng)))
                     multiplier = German.NUMBER_DICT_GER[ng[hundred_index - 1]]
                     equation += "(" + str(multiplier) + " * 100)"
                     equation_results.append(multiplier * 100)


### PR DESCRIPTION
close #100
This tries to tackle the issue by requiring that a multiplier must be before a "hundred construction" so that something like "dreizehn siebenhundert" is no longer summed.