### PR TITLE
Carrying last word context forward in a segment

### DIFF
--- a/tests/test_text_to_num_en.py
+++ b/tests/test_text_to_num_en.py
@@ -175,6 +175,10 @@ class TestTextToNumEN(TestCase):
         self.assertEqual(alpha2digit(source, "en"), source)
         source = "one cannot know"
         self.assertEqual(alpha2digit(source, "en"), source)
+        # Following an ordinal
+        source = "the sixth one"
+        expected = "the 6th one"
+        self.assertEqual(alpha2digit(source, "en"), expected)
         # End of segment
         source = "No one. Another one. One one. Twenty one"
         expected = "No one. Another one. 1 1. 21"

--- a/text_to_num/parsers.py
+++ b/text_to_num/parsers.py
@@ -556,6 +556,7 @@ class WordToDigitParser:
         relaxed: bool = False,
         signed: bool = True,
         ordinal_threshold: int = 3,
+        preceding_word: Optional[str] = None
     ) -> None:
         """Initialize the parser.
 
@@ -575,7 +576,7 @@ class WordToDigitParser:
         self.in_frac = False
         self.closed = False  # For deferred stop
         self.open = False  # For efficiency
-        self.last_word: Optional[str] = None  # For context
+        self.last_word: Optional[str] = preceding_word  # For context
         self.ordinal_threshold = ordinal_threshold
 
     @property

--- a/text_to_num/transforms.py
+++ b/text_to_num/transforms.py
@@ -137,6 +137,7 @@ def alpha2digit(
                 signed=signed,
                 ordinal_threshold=ordinal_threshold,
             )
+            last_word = None
             in_number = False
             out_tokens: List[str] = []
             for word, ahead in look_ahead(tokens):
@@ -149,10 +150,12 @@ def alpha2digit(
                         relaxed=relaxed,
                         signed=signed,
                         ordinal_threshold=ordinal_threshold,
+                        preceding_word=last_word
                     )
                     in_number = num_builder.push(word.lower(), ahead and ahead.lower())
                 if not in_number:
                     out_tokens.append(word)
+                last_word = word.lower()
             # End of segment
             num_builder.close()
             if num_builder.value:


### PR DESCRIPTION
The "last word" context wasn't carried forward within a segment after a number (digits or ordinal) was resolved. This resulted in phrases like the "sixth one" being transposed to the "6th 1". This is in English. This change fixes this so now:
`alpha2digit("the sixth one", "en") --> "the 6th one"`

```
>>> from text_to_num import alpha2digit
>>> alpha2digit("the sixth one", "en")
'the 6th one'
>>> alpha2digit("sixth one", "en")
'6th one'
>>> alpha2digit("six one", "en")
'6 1'
>>> alpha2digit("the sixth. one", "en")
'the 6th. 1'
```