### PR TITLE
Remove 'cienta' from Spanish-hundred dictionary

### DIFF
--- a/text_to_num/lang/spanish.py
+++ b/text_to_num/lang/spanish.py
@@ -82,7 +82,6 @@ MTENS_WSTENS: Set[str] = set()
 HUNDRED = {
     "cien": 100,
     "ciento": 100,
-    "cienta": 100,
     "doscientos": 200,
     "trescientos": 300,
     "cuatrocientos": 400,


### PR DESCRIPTION
Cienta' is not used in the Spanish language under any circumstance. This change removes an invalid word from the Spanish-hundred dictionary.